### PR TITLE
Add Nonprofit Explorer to irs990 DataAtWork

### DIFF
--- a/datasets/irs990.yaml
+++ b/datasets/irs990.yaml
@@ -29,3 +29,7 @@ DataAtWork:
     URL: https://lecy.github.io/Open-Data-for-Nonprofit-Research/
     AuthorName: lecy
     AuthorURL: https://github.com/lecy
+  - Title: Nonprofit Explorer
+    URL: https://projects.propublica.org/nonprofits/
+    AuthorName: ProPublica
+    AuthorURL: https://propublica.org


### PR DESCRIPTION
My colleagues and I at ProPublica think our [Nonprofit Explorer](https://projects.propublica.org/nonprofits) app could be a good addition to the example uses of the irs990 dataset. It's an actively updated research/educational tool making use of the data.

Love the new registry, keep up the good work! 😊