### PR TITLE
Fixing DataAtWork

### DIFF
--- a/datasets/1000-genomes.yaml
+++ b/datasets/1000-genomes.yaml
@@ -19,8 +19,3 @@ DataAtWork:
     URL: https://aws.amazon.com/blogs/big-data/exploratory-data-analysis-of-genomic-datasets-using-adam-and-mango-with-apache-spark-on-amazon-emr/
     AuthorName: Alyssa Marrow
     AuthorURL: https://research.eecs.berkeley.edu/~akmorrow/
-DataAtWork:
-  - Title: Running Mango from Amazon EMR
-    URL: https://github.com/bigdatagenomics/mango/blob/master/docs/cloud/emr.rst
-    AuthorName: Big Data Genomics
-    AuthorURL: http://bdgenomics.org


### PR DESCRIPTION
Also removing old MANGO link. The link to the blog post is enough for this example.