### PR TITLE
Removing non tutorial examples from DataAtWork

### DIFF
--- a/datasets/ecmwf-era5.yaml
+++ b/datasets/ecmwf-era5.yaml
@@ -28,11 +28,3 @@ DataAtWork:
     URL: https://github.com/planet-os/notebooks/blob/master/api-examples/ERA5_tutorial.ipynb
     AuthorName: Intertrust Technologies Corporation
     AuthorURL: https://www.intertrust.com/
-  - Title: "ERA5: The new champion of wind power modelling?"
-    URL: https://doi.org/10.1016/j.renene.2018.03.056
-    AuthorName: Jon Olauson
-    AuthorURL: https://orcid.org/0000-0003-4921-8345
-  - Title: Evaluation of global horizontal irradiance estimates
-    URL: https://doi.org/10.1016/j.solener.2018.02.059
-    AuthorName: Ruben Urraca et. al.
-    AuthorURL: https://www.researchgate.net/profile/Ruben_Urraca

--- a/datasets/ecmwf-era5.yaml
+++ b/datasets/ecmwf-era5.yaml
@@ -3,6 +3,7 @@ Description: |
   ERA5 is the fifth generation of ECMWF atmospheric reanalyses of the global climate, and the first reanalysis produced as an operational service. It utilizes the best available observation data from satellites and in-situ stations, which are assimilated and processed using ECMWF's Integrated Forecast System (IFS) Cycle 41r2.
   The dataset provides all essential atmospheric meteorological parameters like, but not limited to, air temperature, pressure and wind at different altitudes, along with surface parameters like rainfall, soil moisture content and sea parameters like sea-surface temperature and wave height.
   ERA5 provides data at a considerably higher spatial and temporal resolution than its legacy counterpart ERA-Interim. ERA5 consists of high resolution version with 31 km horizontal resolution, and a reduced resolution ensemble version with 10 members. It is currently available since 2008, but will be continuously extended backwards, first until 1979 and then to 1950.
+  Learn more about ERA5 in Jon Olauson's paper [ERA5: The new champion of wind power modelling?](https://www.researchgate.net/publication/320084119_ERA5_The_new_champion_of_wind_power_modelling).
 Documentation: https://github.com/planet-os/notebooks/blob/master/aws/era5-pds.md
 Contact: datahub@intertrust.com
 UpdateFrequency: Monthly


### PR DESCRIPTION
I'm curious to know what people (👋 @jflasher and @ckalima) think about removing these usage examples. Our spec says that DataAtWork is for "A list of links to examples of the dataset being used. May include tutorials, demos, or applications." The papers posted here fit the definition of examples of the data being used, but they're behind a paywall. 

Perhaps we should update the spec to be clearer about what we'd like to see here. Perhaps: "A list of links to examples of the dataset being used on AWS. May include tutorials, demos, or applications."