### PR TITLE
Add Elevation Service to DataAtWork

### DIFF
--- a/datasets/terrain-tiles.yaml
+++ b/datasets/terrain-tiles.yaml
@@ -37,3 +37,7 @@ DataAtWork:
     URL: https://eos.com/landviewer/
     AuthorName: Earth Observing System
     AuthorURL: https://eos.com/
+  - Title: Open-Source Elevation Service
+    URL: https://elevation.racemap.com
+    AuthorName: Racemap
+    AuthorURL: https://racemap.com/


### PR DESCRIPTION
Adds my self-hosted elevation service to the data at work section of the terrain tile data.