### PR TITLE
Entry for the Broad Cell Painting Image Collection

### DIFF
--- a/datasets/cell-painting-image-collection.yaml
+++ b/datasets/cell-painting-image-collection.yaml
@@ -14,12 +14,12 @@ Description: |
   applications.  
 Documentation: https://github.com/cytodata/cytodata-hackathon-2018
 Contact: imagingadmin@broadinstitute.org
-UpdateFrequency: unregularly 
+UpdateFrequency: irregularly 
 Tags:
   - microscopy 
   - high-throughput imaging
   - cell imaging
-  - Cell Painting
+  - cell Painting
   - fluorescence imaging
 License:  CC0 1.0 Universal (CC0 1.0) Public Domain Dedication
 Resources:
@@ -28,19 +28,6 @@ Resources:
     Region: us-east-1
     Type: S3 Bucket
 DataAtWork:
-  - Title: Toward performance-diverse small-molecule libraries for cell-based phenotypic screening using multiplexed high-dimensional profiling
-    URL: https://doi.org/10.1073/pnas.1410933111
-    AuthorName: Wawer et al.
-    AuthorURL: broadinstitute.org
-  - Title: A dataset of images and morphological profiles of 30,000 small-molecule treatments using the Cell Painting assay
-    URL: https://academic.oup.com/gigascience/article/6/12/giw014/2865213
-    AuthorName: Bray et al. 
-    AuthorURL: broadinstitute.org
-  - Title: Systematic morphological profiling of human gene and allele function via Cell Painting
-    URL: https://elifesciences.org/articles/24060
-    AuthorName: Mohammad Hossein Rohban
-    AuthorURL: https://www.broadinstitute.org/imaging
-    DataAtWork:
   - Title: Example submission for the 2018 CytoData Hackathon (in R and Python)
     URL: https://github.com/cytodata/cytodata-hackathon-2018/tree/master/cytodata-toolkit/
     AuthorName: Juan Caicedo, Tim Becker

--- a/datasets/cell-painting-image-collection.yaml
+++ b/datasets/cell-painting-image-collection.yaml
@@ -19,7 +19,7 @@ Tags:
   - microscopy 
   - high-throughput imaging
   - cell imaging
-  - cell Painting
+  - cell painting
   - fluorescence imaging
 License:  CC0 1.0 Universal (CC0 1.0) Public Domain Dedication
 Resources:

--- a/datasets/cell-painting-image-collection.yaml
+++ b/datasets/cell-painting-image-collection.yaml
@@ -1,0 +1,46 @@
+Name: Cell Painting Image Collection
+Description: 
+  The Cell Painting Image Collection is a collection of freely 
+  downloadable microscopy image sets. Cell Painting is an 
+  unbiased high throughput imaging assay used to analyze 
+  perturbations in cell models. In addition to the images 
+  themselves, each set includes a description of the biological 
+  application and some type of "ground truth" (expected results). 
+  Researchers are encouraged to use these image sets as reference 
+  points when developing, testing, and publishing new image 
+  analysis algorithms for the life sciences. We hope that the 
+  this data set will lead to a better understanding of which 
+  methods are best for various biological image analysis 
+  applications.  
+Contact: imagingadmin@broadinstitute.org
+UpdateFrequency: unregularly 
+Tags:
+  - high throughput imaging
+  - cell imaging
+  - microscopy 
+  - Cell Painting
+  - fluorescence imaging
+License: CC0 1.0 Universal (CC0 1.0) Public Domain Dedication (datasets Bioactives-BBBC022-Gustafsdottir, CDRPBIO-BBBC036-Bray, LUAD-BBBC041-Caicedo) and CC BY 4.0 (TA-ORF-BBBC037-Rohban)
+Resources:
+  - Description: Images, extracted features and aggregated profiles are available as a S3 bucket 
+    ARN: arn:aws:s3:::cytodata
+    Region: us-east-1
+    Type: S3 Bucket
+DataAtWork:
+  - Title: Toward performance-diverse small-molecule libraries for cell-based phenotypic screening using multiplexed high-dimensional profiling
+    URL: https://doi.org/10.1073/pnas.1410933111
+    AuthorName: Wawer et al.
+    AuthorURL: broadinstitute.org
+  - Title: A dataset of images and morphological profiles of 30,000 small-molecule treatments using the Cell Painting assay
+    URL: https://academic.oup.com/gigascience/article/6/12/giw014/2865213
+    AuthorName: Bray et al. 
+    AuthorURL: broadinstitute.org
+  - Title: Systematic morphological profiling of human gene and allele function via Cell Painting
+    URL: https://elifesciences.org/articles/24060
+    AuthorName: Mohammad Hossein Rohban
+    AuthorURL: https://www.broadinstitute.org/imaging
+    DataAtWork:
+  - Title: Example submission for the 2018 CytoData Hackathon (in R and Python)
+    URL: https://github.com/cytodata/cytodata-hackathon-2018/tree/master/cytodata-toolkit/
+    AuthorName: Juan Caicedo, Tim Becker
+    AuthorURL: broadinstitute.org

--- a/datasets/cell-painting-image-collection.yaml
+++ b/datasets/cell-painting-image-collection.yaml
@@ -12,15 +12,16 @@ Description:
   this data set will lead to a better understanding of which 
   methods are best for various biological image analysis 
   applications.  
+Documentation: https://github.com/cytodata/cytodata-hackathon-2018
 Contact: imagingadmin@broadinstitute.org
 UpdateFrequency: unregularly 
 Tags:
-  - high throughput imaging
+  - high-throughput imaging
   - cell imaging
   - microscopy 
   - Cell Painting
   - fluorescence imaging
-License: CC0 1.0 Universal (CC0 1.0) Public Domain Dedication (datasets Bioactives-BBBC022-Gustafsdottir, CDRPBIO-BBBC036-Bray, LUAD-BBBC041-Caicedo) and CC BY 4.0 (TA-ORF-BBBC037-Rohban)
+License:  CC0 1.0 Universal (CC0 1.0) Public Domain Dedication
 Resources:
   - Description: Images, extracted features and aggregated profiles are available as a S3 bucket 
     ARN: arn:aws:s3:::cytodata

--- a/datasets/cell-painting-image-collection.yaml
+++ b/datasets/cell-painting-image-collection.yaml
@@ -16,9 +16,9 @@ Documentation: https://github.com/cytodata/cytodata-hackathon-2018
 Contact: imagingadmin@broadinstitute.org
 UpdateFrequency: unregularly 
 Tags:
+  - microscopy 
   - high-throughput imaging
   - cell imaging
-  - microscopy 
   - Cell Painting
   - fluorescence imaging
 License:  CC0 1.0 Universal (CC0 1.0) Public Domain Dedication

--- a/datasets/cell-painting-image-collection.yaml
+++ b/datasets/cell-painting-image-collection.yaml
@@ -1,5 +1,5 @@
 Name: Cell Painting Image Collection
-Description: 
+Description: |
   The Cell Painting Image Collection is a collection of freely 
   downloadable microscopy image sets. Cell Painting is an 
   unbiased high throughput imaging assay used to analyze 


### PR DESCRIPTION
Entry for the Cell Painting Image Collection from the Broad Institute. The collections contain data from three previously published datasets and one newly published data set.  