### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ The metadata required for each dataset entry is as follows:
 |**Resources > ARN**|String|Amazon Resource Name for resource, e.g. arn:aws:s3:::commoncrawl|
 |**Resources > Region**|String|AWS region unique identifier, e.g. us-east-1|
 |**Resources > Type**|String|Can be _CloudFront Distribution_, _DB Snapshot_, _S3 Bucket_, or _SNS Topic_. A list of supported resources is maintained in the [resources.yaml](resources.yaml) file in this repo. If you want to recommend a resource that is not included in [resources.yaml](resources.yaml), please submit a pull request to add it to that file.|
-|**DataAtWork** (Optional)|List of lists|A list of links to examples of the dataset being used. May include tutorials, demos, or applications.|
+|**DataAtWork** (Optional)|List of lists|A list of links to examples of the dataset being used on AWS. May include tutorials, demos, or applications.|
 |**DataAtWork > Title**|String|The title of the example usage of the data.|
 |**DataAtWork > URL**|URL|A link to the example.|
 |**DataAtWork > AuthorName**|String|Name of person or entity that created the example.|


### PR DESCRIPTION
Clarifying purpose of DataAtWork section to specify that examples should be of data being used on AWS.