### PR TITLE
Add terrain-tiles usage example

### DIFF
--- a/datasets/terrain-tiles.yaml
+++ b/datasets/terrain-tiles.yaml
@@ -41,3 +41,7 @@ DataAtWork:
     URL: https://elevation.racemap.com
     AuthorName: Racemap
     AuthorURL: https://racemap.com/
+  - Title: On The Go Map
+    URL: https://onthegomap.com/
+    AuthorName: On The Go Map
+    AuthorURL: https://onthegomap.com/


### PR DESCRIPTION
I recently added an elevation profile feature to https://onthegomap.com/ using the terrain tiles.