### PR TITLE
Updates for Common Crawl s3://commoncrawl/

### DIFF
--- a/datasets/commoncrawl.yaml
+++ b/datasets/commoncrawl.yaml
@@ -43,7 +43,7 @@ DataAtWork:
   - Title: Web Data Commons - RDFa, microdata, and microformat data sets
     URL: http://webdatacommons.org/structureddata/
     AuthorName: Christian Bizer, Robert Meusel, Anna Primpeli
-  - Title: C4Corpus: Multilingual Web-Size Corpus with Free License
+  - Title: C4Corpus&#58; Multilingual Web-Size Corpus with Free License
     URL: http://www.lrec-conf.org/proceedings/lrec2016/pdf/388_Paper.pdf
     AuthorName: Ivan Habernal, Omnia Zayed, Iryna Gurevych
     AuthorURL: https://dkpro.github.io/dkpro-c4corpus/

--- a/datasets/commoncrawl.yaml
+++ b/datasets/commoncrawl.yaml
@@ -1,5 +1,5 @@
 Name: Common Crawl
-Description: A corpus of web crawl data composed of over 5 billion web pages.
+Description: A corpus of web crawl data composed of over 25 billion web pages.
 Documentation: http://commoncrawl.org/the-data/get-started/
 Contact: http://commoncrawl.org/connect/contact-us/
 UpdateFrequency: Monthly
@@ -26,3 +26,31 @@ DataAtWork:
   - Title: Index to WARC Files and URLs in Columnar Format
     URL: http://commoncrawl.org/2018/03/index-to-warc-files-and-urls-in-columnar-format/
     AuthorName: Sebastian Nagel
+  - Title: Learning word vectors for 157 languages
+    URL: https://arxiv.org/abs/1802.06893
+    AuthorName: Facebook AI Research
+    AuthorURL: https://fasttext.cc/docs/en/crawl-vectors.html
+  - Title: Using open data to predict market movements
+    URL: https://education.emc.com/content/dam/dell-emc/documents/en-us/2017KS_Ravinder-Using_Open_Data_to_Predict_Market_Movements.pdf
+    AuthorName: DELL EMC
+  - Title: N-gram counts and language models from the Common Crawl
+    URL: http://www.lrec-conf.org/proceedings/lrec2014/pdf/1097_Paper.pdf
+    AuthorName: Christian Buck, Kenneth Heafield, Bas van Ooyen
+    AuthorURL: http://statmt.org/ngrams/
+  - Title: Large-scale analysis of style injection by relative path overwrite
+    URL: https://doi.org/10.1145/3178876.3186090
+    AuthorName: Sajjad Arshad, et al.
+  - Title: Web Data Commons - RDFa, microdata, and microformat data sets
+    URL: http://webdatacommons.org/structureddata/
+    AuthorName: Christian Bizer, Robert Meusel, Anna Primpeli
+  - Title: C4Corpus: Multilingual Web-Size Corpus with Free License
+    URL: http://www.lrec-conf.org/proceedings/lrec2016/pdf/388_Paper.pdf
+    AuthorName: Ivan Habernal, Omnia Zayed, Iryna Gurevych
+    AuthorURL: https://dkpro.github.io/dkpro-c4corpus/
+  - Title: Of using Common Crawl to play Family Feud
+    URL: https://fulmicoton.com/posts/commoncrawl/
+    AuthorName: Paul Masurel
+  - Title: Large-scale graph mining with Spark
+    URL: https://towardsdatascience.com/large-scale-graph-mining-with-spark-750995050656
+    AuthorName: Win Suen
+    AuthorURL: https://github.com/wsuen/pygotham2018_graphmining


### PR DESCRIPTION
- add more data-at-work references and try to cover diverse use cases: natural language processing, semantic web, linked data, information retrieval, data mining, internet security, graph processing
- correct number of unique pages crawled