### PR TITLE
adding PlanetUtils links

### DIFF
--- a/datasets/osm.yaml
+++ b/datasets/osm.yaml
@@ -31,7 +31,7 @@ DataAtWork:
   - Title: Develop and Extract Value from Open Data
     URL: https://aws.amazon.com/blogs/publicsector/develop-and-extract-value-from-open-data/
     AuthorName: Daniel Bernao
-  - Title: PlanetUtils (GitHub): Scripts and a Docker container to maintain your own OpenStreetMap planet
+  - Title: "PlanetUtils (GitHub): Scripts and a Docker container to maintain your own OpenStreetMap planet"
     URL: https://github.com/interline-io/planetutils
     AuthorName: Interline Technologies
     AuthorURL: https://www.interline.io/

--- a/datasets/osm.yaml
+++ b/datasets/osm.yaml
@@ -31,3 +31,7 @@ DataAtWork:
   - Title: Develop and Extract Value from Open Data
     URL: https://aws.amazon.com/blogs/publicsector/develop-and-extract-value-from-open-data/
     AuthorName: Daniel Bernao
+  - Title: PlanetUtils (GitHub): Scripts and a Docker container to maintain your own OpenStreetMap planet
+    URL: https://github.com/interline-io/planetutils
+    AuthorName: Interline Technologies
+    AuthorURL: https://www.interline.io/

--- a/datasets/terrain-tiles.yaml
+++ b/datasets/terrain-tiles.yaml
@@ -45,3 +45,7 @@ DataAtWork:
     URL: https://onthegomap.com/
     AuthorName: On The Go Map
     AuthorURL: https://onthegomap.com/
+  - Title: PlanetUtils (GitHub): Scripts and a Docker container to download, merge, and resample terrain tiles
+    URL: https://github.com/interline-io/planetutils
+    AuthorName: Interline Technologies
+    AuthorURL: https://www.interline.io/

--- a/datasets/terrain-tiles.yaml
+++ b/datasets/terrain-tiles.yaml
@@ -45,7 +45,7 @@ DataAtWork:
     URL: https://onthegomap.com/
     AuthorName: On The Go Map
     AuthorURL: https://onthegomap.com/
-  - Title: PlanetUtils (GitHub): Scripts and a Docker container to download, merge, and resample terrain tiles
+  - Title: "PlanetUtils (GitHub): Scripts and a Docker container to download, merge, and resample terrain tiles"
     URL: https://github.com/interline-io/planetutils
     AuthorName: Interline Technologies
     AuthorURL: https://www.interline.io/


### PR DESCRIPTION
- PlanetUtils `osm_planet_update` command can download from the OSM planet PDS
- PlanetUtils `elevation_tile_download` command downloads from the Amazon/Mapzen Terrain Tiles PDS