### PR TITLE
Added OpenLitterMap.yarn

### DIFF
--- a/datasets/openlittermap.yaml
+++ b/datasets/openlittermap.yaml
@@ -1,0 +1,23 @@
+Name: OpenLitterMap,
+Description: Open Data on Plastic Pollution with Blockchain Rewards (Littercoin)
+Contact: info@openlittermap.com
+ManagedBy: Seán Lynch 
+UpdateFrequency: Weekly
+Tags:
+  - Plastic Pollution
+  - Citizen Science
+  - Blockchain
+  - OpenLitterMap
+  - Littercoin
+  - Environment
+License: Open Database License (ODbL)
+Resources:
+  - Description: https://opengeospatialdata.springeropen.com/articles/10.1186/s40965-018-0050-y
+    ARN: olm-s3
+    Region: eu-west-1
+    Type: t2.micro, s3
+DataAtWork:
+  - Title: OpenLitterMap.com - Open Data on Plastic Pollution with Blockchain Rewards (Littercoin)
+    URL: https://opengeospatialdata.springeropen.com/articles/10.1186/s40965-018-0050-y
+    AuthorName: Seán Lynch
+    AuthorURL: https://linkedin.com/in/seanlynchgis


### PR DESCRIPTION
Added OpenLitterMap.yarn

OpenLitterMap.com empowers and incentivises anyone to map and share open data on plastic pollution anywhere

See
https://opengeospatialdata.springeropen.com/articles/10.1186/s40965-018-0050-y