### PR TITLE
Changed documentation and added EO Browser

### DIFF
--- a/datasets/sentinel-1.yaml
+++ b/datasets/sentinel-1.yaml
@@ -1,6 +1,6 @@
 Name: Sentinel-1
-Description: "[Sentinel-1](https://sentinel.esa.int/web/sentinel/missions/sentinel-1) is a pair of European radar imaging (SAR) satellites launched in 2014 and 2016. Its 6 days revisit cycle and ability to observe through clouds makes it perfect for sea and land monitoring, emergency response due to environmental disasters, and economic applications."
-Documentation: http://sentinel-pds.s3-website.eu-central-1.amazonaws.com/
+Description: "[Sentinel-1](https://sentinel.esa.int/web/sentinel/missions/sentinel-1) is a pair of European radar imaging (SAR) satellites launched in 2014 and 2016. Its 6 days revisit cycle and ability to observe through clouds makes it perfect for sea and land monitoring, emergency response due to environmental disasters, and economic applications. The data is available globally since January 2017."
+Documentation: https://roda.sentinel-hub.com/sentinel-s1-l1c/GRD/readme.html
 Contact: https://forum.sentinel-hub.com/c/aws-sentinel
 ManagedBy: "[Sinergise](https://www.sinergise.com/)"
 UpdateFrequency: New Sentinel data are added regularly, usually within few hours after they are available on Copernicus OpenHub.
@@ -39,3 +39,7 @@ DataAtWork:
     URL: https://eos.com/landviewer/
     AuthorName: Earth Observing System
     AuthorURL: https://eos.com/
+  - Title: EO Browser
+    URL: http://apps.sentinel-hub.com/eo-browser/
+    AuthorName: Sinergise
+    AuthorURL: http://www.sinergise.com/


### PR DESCRIPTION
I also added some info on availability.
EO Browser supports S1 from AWS for a couple of months and even though it is not a default selection (due to lack of pre-2017 archive), the use of AWS option is higher than EO Cloud option.