### PR TITLE
Fix bad Documentation link in USGS LiDAR entry

### DIFF
--- a/datasets/usgs-lidar.yaml
+++ b/datasets/usgs-lidar.yaml
@@ -1,6 +1,6 @@
 Name: USGS 3DEP LiDAR Point Clouds
 Description: The goal of the [USGS 3D Elevation Program ](https://www.usgs.gov/core-science-systems/ngp/3dep) (3DEP) is to collect elevation data in the form of light detection and ranging (LiDAR) data over the conterminous United States, Hawaii, and the U.S. territories, with data acquired over an 8-year period. This dataset provides two realizations of the 3DEP point cloud data. The first resource is a public access organization provided in [Entwine Point Tiles](https://entwine.io/entwine-point-tile.html) format, which a lossless, streamable octree based on [LASzip](https://laszip.org) (LAZ) encoding. The second resource is a [Requester Pays](https://docs.aws.amazon.com/AmazonS3/latest/dev/RequesterPaysBuckets.html) of full-density raw LAZ data. Resource names in both buckets correspond to the USGS project names.
-Documentation: https://github.com/hobu/usgs-lidar/README.rst
+Documentation: https://github.com/hobu/usgs-lidar/
 Contact: https://github.com/hobu/usgs-lidar
 ManagedBy: "[Hobu, Inc.](https://hobu.co)"
 UpdateFrequency: Periodically


### PR DESCRIPTION
The landing link for the documentation was 404.