### PR TITLE
IIT -> IIIT fix typo

### DIFF
--- a/datasets/fast-ai-imageclas.yaml
+++ b/datasets/fast-ai-imageclas.yaml
@@ -1,7 +1,7 @@
 Name: Image classification - fast.ai datasets
 Description: |
   Some of the most important datasets for image classification research, including
-  CIFAR 10 and 100, Caltech 101, MNIST, Food-101, Oxford-102-Flowers, Oxford-IIT-Pets,
+  CIFAR 10 and 100, Caltech 101, MNIST, Food-101, Oxford-102-Flowers, Oxford-IIIT-Pets,
   and Stanford-Cars.  This is part of the fast.ai datasets collection hosted by
   AWS for convenience of fast.ai students. See documentation link for citation and
   license details for each dataset.


### PR DESCRIPTION
Incorrectly mentioned as Oxford IIT Pet Dataset when it is actually Oxford IIIT