### PR TITLE
softwareheritage: add the Ethical Charter and terms of use for bulk access

### DIFF
--- a/datasets/software-heritage.yaml
+++ b/datasets/software-heritage.yaml
@@ -13,6 +13,12 @@ Description: |
     Debian), and language-specific package managers (e.g., PyPI). Crawling
     information is also included, providing timestamps about when and where all
     archived source code artifacts have been observed in the wild.
+
+    By accessing the dataset, you agree with the Software Heritage [Ethical
+    Charter for using the archive
+    data](https://www.softwareheritage.org/legal/users-ethical-charter/) and
+    the [terms of use for bulk
+    access](https://www.softwareheritage.org/legal/bulk-access-terms-of-use/).
 Documentation: https://wiki.softwareheritage.org/wiki/Graph_Dataset_on_Amazon_Athena
 Contact: swh-devel@inria.fr
 UpdateFrequency: Data is updated yearly


### PR DESCRIPTION
*Description of changes:* Software Heritage has an ethical charter for the use of its dataset, to prevent abuse. This commit adds the relevant links to the description.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
