### PR TITLE
softwareheritage: move the Ethical Charter to the License section

### DIFF
--- a/datasets/software-heritage.yaml
+++ b/datasets/software-heritage.yaml
@@ -13,12 +13,6 @@ Description: |
     Debian), and language-specific package managers (e.g., PyPI). Crawling
     information is also included, providing timestamps about when and where all
     archived source code artifacts have been observed in the wild.
-
-    By accessing the dataset, you agree with the Software Heritage [Ethical
-    Charter for using the archive
-    data](https://www.softwareheritage.org/legal/users-ethical-charter/) and
-    the [terms of use for bulk
-    access](https://www.softwareheritage.org/legal/bulk-access-terms-of-use/).
 Documentation: https://wiki.softwareheritage.org/wiki/Graph_Dataset_on_Amazon_Athena
 Contact: swh-devel@inria.fr
 UpdateFrequency: Data is updated yearly
@@ -28,7 +22,14 @@ Tags:
   - open source software
   - free software
   - digital preservation
-License: Creative Commons Attribution 4.0 International
+License: |
+    Creative Commons Attribution 4.0 International.
+
+    By accessing the dataset, you agree with the Software Heritage [Ethical
+    Charter for using the archive
+    data](https://www.softwareheritage.org/legal/users-ethical-charter/) and
+    the [terms of use for bulk
+    access](https://www.softwareheritage.org/legal/bulk-access-terms-of-use/).
 Resources:
   - Description: Software Heritage Graph Dataset
     ARN: arn:aws:s3:::softwareheritage


### PR DESCRIPTION
*Description of changes:* After seeing the result of the last PR on the web UI, we noticed that it was easy to miss the ethical charter because of it being at the end of the description. We wondered if it was possible to move it to the License section, but we're not sure how long this field can be.

Could you confirm that the attached patch renders properly on the web UI of the registry, and if yes, merge the PR? Thanks!

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
