### PR TITLE
Update amazon-reviews.yaml to add an extra AtWork entry

### DIFF
--- a/datasets/amazon-reviews.yaml
+++ b/datasets/amazon-reviews.yaml
@@ -24,3 +24,7 @@ DataAtWork:
     URL: https://github.com/awslabs/amazon-sagemaker-examples/blob/master/introduction_to_applying_machine_learning/gluon_recommender_system/gluon_recommender_system.ipynb
     AuthorName: David Arpin
     AuthorURL: https://github.com/djarpin
+  - Title: Querying Review Data with Kognitio AWS Marketplace product using SQL
+    URL: https://www.linkedin.com/pulse/100-shades-grey-other-amazon-review-discoveries-mark-chopping/
+    AuthorName: Mark Chopping
+    AuthorURL: https://twitter.com/markchopping1


### PR DESCRIPTION
Added details of using SQL to mine the 160 million rows of data using an in-memory database available for a few dollars per hour in AWS

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
