### PR TITLE
Add CloudStory Notebooks Within DataAtWork

### DIFF
--- a/datasets/nyc-tlc-trip-records-pds.yaml
+++ b/datasets/nyc-tlc-trip-records-pds.yaml
@@ -21,3 +21,9 @@ DataAtWork:
   - Title: Build a Real-time Stream Processing Pipeline with Apache Flink on AWS
     URL: https://aws.amazon.com/blogs/big-data/build-a-real-time-stream-processing-pipeline-with-apache-flink-on-aws/
     AuthorName: Steffen Hausmann
+  - Title: Exploring data with Python and Amazon S3 Select
+    URL: https://github.com/manavsehgal/CloudStory/blob/master/open-data-analytics/exploring-data-with-python-and-amazon-s3-select.ipynb
+    AuthorName: Manav Sehgal
+  - Title: Optimizing data for analysis with Amazon Athena and AWS Glue
+    URL: https://github.com/manavsehgal/CloudStory/blob/master/open-data-analytics/optimizing-data-for-analysis-with-amazon-athena-and-aws-glue.ipynb
+    AuthorName: Manav Sehgal


### PR DESCRIPTION
*Issue #, if available:* None

*Description of changes:* Adding CloudStory Notebooks links to GitHub locations


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
