### PR TITLE
Update ncbi-sra.yaml

### DIFF
--- a/datasets/ncbi-sra.yaml
+++ b/datasets/ncbi-sra.yaml
@@ -1,8 +1,8 @@
 Name: NIH NCBI Sequence Research Archive (SRA) on AWS
-Description:  "The Sequence Read Archive (SRA), produced by the [National Center for Biotechnology Information (NCBI)]](https://www.ncbi.nlm.nih.gov/) at the [National Library of Medicine (NLM)](http://nlm.nih.gov/) at the [National Institutes of Health (NIH)](http://nlm.nih.gov/), stores raw DNA sequencing data and alignment information from high-throughput sequencing platforms. The SRA provides open access to these biological sequence data to support the research community's efforts to enhance reproducibility and make new discoveries by comparing data sets. This bucket contains public SRA data in  original format from select high value and newly-released studies."
-Contact: "[SRA Staff](sra@ncbi.nlm.nih.gov)"
+Description:  "The Sequence Read Archive (SRA), produced by the [National Center for Biotechnology Information (NCBI)](https://www.ncbi.nlm.nih.gov/) at the [National Library of Medicine (NLM)](http://nlm.nih.gov/) at the [National Institutes of Health (NIH)](http://nlm.nih.gov/), stores raw DNA sequencing data and alignment information from high-throughput sequencing platforms. The SRA provides open access to these biological sequence data to support the research community's efforts to enhance reproducibility and make new discoveries by comparing data sets. This bucket contains public SRA data in  original format from select high value and newly-released studies."
+Contact: "[sra@ncbi.nlm.nih.gov](sra@ncbi.nlm.nih.gov)"
 Documentation: https://www.ncbi.nlm.nih.gov/sra/docs/sra-cloud/
-ManagedBy: "[National Center for Biotechnology Information (NCBI)]](https://www.ncbi.nlm.nih.gov/) at the [National Library of Medicine (NLM)](http://nlm.nih.gov/) at the [National Institutes of Health (NIH)](http://nlm.nih.gov/)"
+ManagedBy: "[National Center for Biotechnology Information (NCBI)](https://www.ncbi.nlm.nih.gov/) at the [National Library of Medicine (NLM)](http://nlm.nih.gov/) at the [National Institutes of Health (NIH)](http://nlm.nih.gov/)"
 UpdateFrequency: Daily
 Tags:
   - aws-pds

--- a/datasets/ncbi-sra.yaml
+++ b/datasets/ncbi-sra.yaml
@@ -1,6 +1,6 @@
 Name: NIH NCBI Sequence Research Archive (SRA) on AWS
 Description:  "The Sequence Read Archive (SRA), produced by the [National Center for Biotechnology Information (NCBI)](https://www.ncbi.nlm.nih.gov/) at the [National Library of Medicine (NLM)](http://nlm.nih.gov/) at the [National Institutes of Health (NIH)](http://nlm.nih.gov/), stores raw DNA sequencing data and alignment information from high-throughput sequencing platforms. The SRA provides open access to these biological sequence data to support the research community's efforts to enhance reproducibility and make new discoveries by comparing data sets. This bucket contains public SRA data in  original format from select high value and newly-released studies."
-Contact: "[sra@ncbi.nlm.nih.gov](sra@ncbi.nlm.nih.gov)"
+Contact: sra@ncbi.nlm.nih.gov
 Documentation: https://www.ncbi.nlm.nih.gov/sra/docs/sra-cloud/
 ManagedBy: "[National Center for Biotechnology Information (NCBI)](https://www.ncbi.nlm.nih.gov/) at the [National Library of Medicine (NLM)](http://nlm.nih.gov/) at the [National Institutes of Health (NIH)](http://nlm.nih.gov/)"
 UpdateFrequency: Daily


### PR DESCRIPTION
fixing typos in the URL links for NCBI and the link for NCBI Staff was still broken by pointing to https://registry.opendata.aws/ncbi-sra/sra@ncbi.nlm.nih.gov

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
