### PR TITLE
Update ncbi-sra.yaml

### DIFF
--- a/datasets/ncbi-sra.yaml
+++ b/datasets/ncbi-sra.yaml
@@ -2,7 +2,7 @@ Name: NIH NCBI Sequence Research Archive (SRA) on AWS
 Description:  "The Sequence Read Archive (SRA), produced by the [National Center for Biotechnology Information (NCBI)](https://www.ncbi.nlm.nih.gov/) at the [National Library of Medicine (NLM)](http://nlm.nih.gov/) at the [National Institutes of Health (NIH)](http://www.nih.gov/), stores raw DNA sequencing data and alignment information from high-throughput sequencing platforms. The SRA provides open access to these biological sequence data to support the research community's efforts to enhance reproducibility and make new discoveries by comparing data sets. This bucket contains public SRA data in  original format from select high value and newly-released studies."
 Contact: sra@ncbi.nlm.nih.gov
 Documentation: https://www.ncbi.nlm.nih.gov/sra/docs/sra-cloud/
-ManagedBy: "[National Center for Biotechnology Information (NCBI)](https://www.ncbi.nlm.nih.gov/), [National Library of Medicine (NLM)](http://nlm.nih.gov/), [National Institutes of Health (NIH)](https://www.nih.gov/)"
+ManagedBy: "[National Library of Medicine (NLM)](http://nlm.nih.gov/)"
 UpdateFrequency: Daily
 Tags:
   - aws-pds

--- a/datasets/ncbi-sra.yaml
+++ b/datasets/ncbi-sra.yaml
@@ -1,8 +1,8 @@
 Name: NIH NCBI Sequence Research Archive (SRA) on AWS
-Description:  "The Sequence Read Archive (SRA), produced by the [National Center for Biotechnology Information (NCBI)](https://www.ncbi.nlm.nih.gov/) at the [National Library of Medicine (NLM)](http://nlm.nih.gov/) at the [National Institutes of Health (NIH)](http://nlm.nih.gov/), stores raw DNA sequencing data and alignment information from high-throughput sequencing platforms. The SRA provides open access to these biological sequence data to support the research community's efforts to enhance reproducibility and make new discoveries by comparing data sets. This bucket contains public SRA data in  original format from select high value and newly-released studies."
+Description:  "The Sequence Read Archive (SRA), produced by the [National Center for Biotechnology Information (NCBI)](https://www.ncbi.nlm.nih.gov/) at the [National Library of Medicine (NLM)](http://nlm.nih.gov/) at the [National Institutes of Health (NIH)](http://www.nih.gov/), stores raw DNA sequencing data and alignment information from high-throughput sequencing platforms. The SRA provides open access to these biological sequence data to support the research community's efforts to enhance reproducibility and make new discoveries by comparing data sets. This bucket contains public SRA data in  original format from select high value and newly-released studies."
 Contact: sra@ncbi.nlm.nih.gov
 Documentation: https://www.ncbi.nlm.nih.gov/sra/docs/sra-cloud/
-ManagedBy: "[National Center for Biotechnology Information (NCBI)](https://www.ncbi.nlm.nih.gov/) at the [National Library of Medicine (NLM)](http://nlm.nih.gov/) at the [National Institutes of Health (NIH)](http://nlm.nih.gov/)"
+ManagedBy: "[National Center for Biotechnology Information (NCBI)](https://www.ncbi.nlm.nih.gov/), [National Library of Medicine (NLM)](http://nlm.nih.gov/), [National Institutes of Health (NIH)](https://www.nih.gov/)"
 UpdateFrequency: Daily
 Tags:
   - aws-pds


### PR DESCRIPTION
noticed incorrect link to NIH. Auto generated "See all datasets managed by" seems to have the typo for markdown still present.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
