### PR TITLE
add reference to Allen Mouse Brain Atlas tutorial

### DIFF
--- a/datasets/allen-mouse-brain-atlas.yaml
+++ b/datasets/allen-mouse-brain-atlas.yaml
@@ -24,6 +24,10 @@ Resources:
     Type: S3 Bucket
 DataAtWork:
   Tutorials:
+    - Title: Visualizing Images from the Allen Mouse Brain Atlas
+      URL: https://github.com/AllenInstitute/open_dataset_tools/blob/master/Visualizing_Images_from_Allen_Mouse_Brain_Atlas.ipynb
+      AuthorName: Allen Institute for Brain Science
+      AuthorURL: www.alleninstitute.org
   Tools & Applications:
     - Title: Allen Mouse Brain Atlas
       URL: https://mouse.brain-map.org


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
We have recently made public a Jupyter notebook demonstrating how to access and visualize images from the Allen Mouse Brain Atlas dataset. This PR adds a reference to that tutorial to the relevant yaml file.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
