### PR TITLE
Documentation link is outdated

### DIFF
--- a/datasets/software-heritage.yaml
+++ b/datasets/software-heritage.yaml
@@ -13,7 +13,7 @@ Description: |
     Debian), and language-specific package managers (e.g., PyPI). Crawling
     information is also included, providing timestamps about when and where all
     archived source code artifacts have been observed in the wild.
-Documentation: https://wiki.softwareheritage.org/wiki/Graph_Dataset_on_Amazon_Athena
+Documentation: https://docs.softwareheritage.org/devel/swh-dataset/graph/athena.html
 Contact: swh-devel@inria.fr
 UpdateFrequency: Data is updated yearly
 Tags:


### PR DESCRIPTION
The current documentation link works, but it goes to a wiki page with outdated information that point to non-existing resources. The new provided link works fine (just created the Athena datasets by following the instructions)

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
