### PR TITLE
Update formatting for Folding@home initial public dataset release

### DIFF
--- a/datasets/foldingathome-covid19.yaml
+++ b/datasets/foldingathome-covid19.yaml
@@ -52,7 +52,7 @@ UpdateFrequency: Datasets will be updated periodically as additional simulations
 Tags:
   - aws-pds
   - COVID-19
-  - "Folding@home"
+  - foldingathome
   - SARS-CoV-2
   - coronavirus
   - simulations

--- a/datasets/foldingathome-covid19.yaml
+++ b/datasets/foldingathome-covid19.yaml
@@ -66,11 +66,11 @@ DataAtWork:
       URL: https://covid.molssi.org//simulations/#foldinghome-simulations-of-the-sars-cov-2-spike-protein-spike-spike-binding
       AuthorName: MolSSI COVID Molecular Structure and Therapeutics Hub
       AuthorURL: https://covid.molssi.org
-    - Title: SARS-CoV-2 main viral protease simulations: A 2.6 ms dataset of the SARS-CoV-2 main viral protease (apo, monomer).
+    - Title: "SARS-CoV-2 main viral protease simulations: A 2.6 ms dataset of the SARS-CoV-2 main viral protease (apo, monomer)."
       URL: https://covid.molssi.org//simulations/#foldinghome-sars-cov-2-main-protease-apo-monomer-simulations-3clpro-3clpro-protease-activity
       AuthorName: MolSSI COVID Molecular Structure and Therapeutics Hub
       AuthorURL: https://covid.molssi.org
-    - Title: SARS-CoV-2 COVID Moonshot absolute free energy calculations
+    - Title: "SARS-CoV-2 COVID Moonshot absolute free energy calculations"
       URL: https://covid.molssi.org//simulations/#foldinghome-expanded-ensemble-absolute-free-energy-calculations-of-potential-small-molecule-inhibitors-of-the-sars-cov-2-main-protease-from-the-covid-moonshot-3clpro-3clpro-protease-activity
       AuthorName: MolSSI COVID Molecular Structure and Therapeutics Hub
       AuthorURL: https://covid.molssi.org

--- a/datasets/foldingathome-covid19.yaml
+++ b/datasets/foldingathome-covid19.yaml
@@ -39,17 +39,17 @@ Description: >
 
   **SARS-CoV-2 spike protein dataset:**
   A 1.2 ms dataset of the SARS-CoV-2 spike protein.
-  [[MolSSI COVID Hub]](https://covid.molssi.org//simulations/#trajectories-of-the-sars-cov-2-spike-protein-from-foldinghome-spike-nil)
+  [[MolSSI COVID Hub]](https://covid.molssi.org//simulations/#foldinghome-simulations-of-the-sars-cov-2-spike-protein-spike-nil)
 
 
   **SARS-CoV-2 main viral protease simulations:**
   A 2.6 ms dataset of the SARS-CoV-2 main viral protease (apo, monomer).
-  [[MolSSI COVID Hub]](https://covid.molssi.org//simulations/#sars-cov-2-main-protease-apo-monomer-foldinghome-simulations-3clpro-3clpro-protease-activity)
+  [[MolSSI COVID Hub]](https://covid.molssi.org//simulations/#foldinghome-sars-cov-2-main-protease-apo-monomer-simulations-3clpro-3clpro-protease-activity)
 
 
   **SARS-CoV-2 COVID Moonshot absolute free energy calculations:**
   Absolute alchemical free energy calculations of crowdsourced molecule designs for the [COVID Moonshot](http://postera.ai/covid).
-  [[MolSSI COVID Hub]](https://covid.molssi.org//simulations/#trajectories-of-the-sars-cov-2-main-protease-protein-from-foldinghome-3clpro-nil)
+  [[MolSSI COVID Hub]](https://covid.molssi.org//simulations/#foldinghome-expanded-ensemble-absolute-free-energy-calculations-of-potential-small-molecule-inhibitors-of-the-sars-cov-2-main-protease-from-the-covid-moonshot-3clpro-nil)
 
 Documentation: https://github.com/FoldingAtHome/coronavirus
 Contact: "[Folding@home](https://foldingathome.org/contact-us/)"

--- a/datasets/foldingathome-covid19.yaml
+++ b/datasets/foldingathome-covid19.yaml
@@ -1,36 +1,86 @@
 Name: Foldingathome COVID-19 Datasets
-Description: Folding@home is a massively distributed computing project for running molecular dynamics simulations. In the light of the COVID19 pandemic, it has heavily focused its resources to understand SARS-CoV-2, and develop therapeutics associated with COVID-19 disease. Efforts include simulation of the viral proteome to uncover functional dynamics and cryptic pockets, detail mechanisms of infection, understand antibody binding mechanisms, and identify new small molecule therapeutics. This repository contains several major datasets from this effort and comprises the single largest collection of molecular simulation.
+Description: >
+  [Folding@home](http://foldingathome.org) is a massively distributed computing
+  project that uses biomolecular simulations to investigate the [molecular origins of disease](https://foldingathome.org/diseases/)
+  and accelerate the discovery of new therapies. Run by the
+  [Folding@home Consortium](https://foldingathome.org/about/the-foldinghome-consortium/),
+  a worldwide network of research laboratories focusing on a variety of different
+  diseases, Folding@home seeks to address problems in human health on a scale
+  that is infeasible by another other means, sharing the results of these large-scale
+  studies with the research community through [peer-reviewed publications](https://foldingathome.org/papers-results/)
+  and publicly shared datasets.
+
+  During the [COVID-19 epidemic](https://en.wikipedia.org/wiki/Coronavirus_disease_2019),
+  Folding@home focused its resources on understanding the vulernabilities in
+  [SARS-CoV-2](https://en.wikipedia.org/wiki/Severe_acute_respiratory_syndrome_coronavirus_2),
+  the virus that causes COVID-19 disease, and working closely with a number of
+  experimental collaborators to accelerate progress toward effective therapies for
+  treating COVID-19 and ending the pandemic. In the process, it created the world's first
+  [exascale distributed computing resource](https://doi.org/10.1101/2020.06.27.175430),
+  enabling it to generate valuable scientific datasets of unprecedented size.
+  More information about Folding@home's COVID-19 research activities at the
+  [Folding@home COVID-19 page](https://foldingathome.org/diseases/infectious-diseases/covid-19/).
+
+  In addition to working directly with experimental collaborators and rapidly sharing
+  new research findings through preprint servers, Folding@home has joined other
+  researchers in committing to [rapidly share all COVID-19 research data](https://doi.org/10.1021/acs.jcim.0c00319),
+  and has joined forces with [AWS](https://aws.amazon.com/) and the
+  [Molecular Sciences Software Institute (MolSSI)](http://molssi.org) to share datasets of unprecented side
+  through the [AWS Open Data Registry](https://registry.opendata.aws/),
+  indexing these massive datsets via the [MolSSI COVID-19 Molecular Structure and Therapeutics Hub](https://covid.molssi.org/).
+  This repository contains several major datasets from this effort and comprises
+  the single largest collection of molecular simulation data ever released.
+
+  The following datasets are available at this time:
+
+  **SARS-CoV-2 spike protein dataset:**
+  A 1.2 ms dataset of the SARS-CoV-2 spike protein.
+  [[MolSSI COVID Hub]](https://covid.molssi.org//simulations/#trajectories-of-the-sars-cov-2-spike-protein-from-foldinghome-spike-nil)
+
+  **SARS-CoV-2 main viral protease simulations:**
+  A 2.6 ms dataset of the SARS-CoV-2 main viral protease (apo, monomer).
+  [[MolSSI COVID Hub]](https://covid.molssi.org//simulations/#sars-cov-2-main-protease-apo-monomer-foldinghome-simulations-3clpro-3clpro-protease-activity)
+
+  **SARS-CoV-2 COVID Moonshot absolute free energy calculations:**
+  Absolute alchemical free energy calculations of crowdsourced molecule designs for the [COVID Moonshot](http://postera.ai/covid).
+  [[MolSSI COVID Hub]](https://covid.molssi.org//simulations/#trajectories-of-the-sars-cov-2-main-protease-protein-from-foldinghome-3clpro-nil)
+
 Documentation: https://github.com/FoldingAtHome/coronavirus
 Contact: "[Folding@home](https://foldingathome.org/contact-us/)"
 ManagedBy: "[Folding@home](https://foldingathome.org)"
-UpdateFrequency: Datasets will be updated periodically as further simulations are completed
+UpdateFrequency: Datasets will be updated periodically as additional simulations are completed.
 Tags:
   - aws-pds
   - COVID-19
+  - Folding@home
+  - SARS-CoV-2
   - coronavirus
   - simulations
   - health
   - life sciences
   - protein
+  - biomolecular simulations
+  - molecular dynamics
+  - alchemical free energy calculations
+  - absolute free energy calculations
+  - relative free energy calculations
+  - structural biology
 License: "[CC0](https://creativecommons.org/share-your-work/public-domain/cc0/)"
 Resources:
-  - Description: Simulation of SARS-CoV-2 proteome and related. Emphasis on discovering cryptic pockets and functional dynamics.
+  - Description: <
+      Simulations of SARS-CoV-2 and associated host proteins, with emphasis on discovering druggable cryptic pockets.
     ARN: arn:aws:s3:::fah-public-data-covid19-cryptic-pockets
     Region: us-east-2
     Type: S3 Bucket
-  - Description: 
+  - Description: <
+      Absolute free energy calculations of small molecules from the [COVID Moonshot](http://postera.ai).
+      [[MolSSI COVID Hub]](https://covid.molssi.org//simulations/#trajectories-of-the-sars-cov-2-main-protease-protein-from-foldinghome-3clpro-nil)
     ARN: arn:aws:s3:::fah-public-data-covid19-absolute-free-energy
     Region: us-east-2
     Type: S3 Bucket
-  - Description: 
-    ARN: arn:aws:s3:::fah-public-data-covid19-relative-free-energy
-    Region: us-east-2
-    Type: S3 Bucket
-  - Description: 
-    ARN: arn:aws:s3:::fah-public-data-covid19-antibodies
-    Region: us-east-2
-    Type: S3 Bucket
-  - Description: 
+  - Description: <
+      Simulations of target proteins and bound small molecules from the [COVID Moonshot](http://postera.ai).
+      [[MolSSI COVID Hub]](https://covid.molssi.org//simulations/#trajectories-of-the-sars-cov-2-main-protease-protein-from-foldinghome-3clpro-nil)
     ARN: arn:aws:s3:::fah-public-data-covid19-moonshot-dynamics
     Region: us-east-2
     Type: S3 Bucket

--- a/datasets/foldingathome-covid19.yaml
+++ b/datasets/foldingathome-covid19.yaml
@@ -10,6 +10,7 @@ Description: >
   studies with the research community through [peer-reviewed publications](https://foldingathome.org/papers-results/)
   and publicly shared datasets.
 
+
   During the [COVID-19 epidemic](https://en.wikipedia.org/wiki/Coronavirus_disease_2019),
   Folding@home focused its resources on understanding the vulernabilities in
   [SARS-CoV-2](https://en.wikipedia.org/wiki/Severe_acute_respiratory_syndrome_coronavirus_2),
@@ -21,6 +22,7 @@ Description: >
   More information about Folding@home's COVID-19 research activities at the
   [Folding@home COVID-19 page](https://foldingathome.org/diseases/infectious-diseases/covid-19/).
 
+
   In addition to working directly with experimental collaborators and rapidly sharing
   new research findings through preprint servers, Folding@home has joined other
   researchers in committing to [rapidly share all COVID-19 research data](https://doi.org/10.1021/acs.jcim.0c00319),
@@ -31,15 +33,19 @@ Description: >
   This repository contains several major datasets from this effort and comprises
   the single largest collection of molecular simulation data ever released.
 
+
   The following datasets are available at this time:
+
 
   **SARS-CoV-2 spike protein dataset:**
   A 1.2 ms dataset of the SARS-CoV-2 spike protein.
   [[MolSSI COVID Hub]](https://covid.molssi.org//simulations/#trajectories-of-the-sars-cov-2-spike-protein-from-foldinghome-spike-nil)
 
+
   **SARS-CoV-2 main viral protease simulations:**
   A 2.6 ms dataset of the SARS-CoV-2 main viral protease (apo, monomer).
   [[MolSSI COVID Hub]](https://covid.molssi.org//simulations/#sars-cov-2-main-protease-apo-monomer-foldinghome-simulations-3clpro-3clpro-protease-activity)
+
 
   **SARS-CoV-2 COVID Moonshot absolute free energy calculations:**
   Absolute alchemical free energy calculations of crowdsourced molecule designs for the [COVID Moonshot](http://postera.ai/covid).

--- a/datasets/foldingathome-covid19.yaml
+++ b/datasets/foldingathome-covid19.yaml
@@ -9,8 +9,6 @@ Description: >
   that is infeasible by another other means, sharing the results of these large-scale
   studies with the research community through [peer-reviewed publications](https://foldingathome.org/papers-results/)
   and publicly shared datasets.
-
-
   During the [COVID-19 epidemic](https://en.wikipedia.org/wiki/Coronavirus_disease_2019),
   Folding@home focused its resources on understanding the vulernabilities in
   [SARS-CoV-2](https://en.wikipedia.org/wiki/Severe_acute_respiratory_syndrome_coronavirus_2),
@@ -21,8 +19,6 @@ Description: >
   enabling it to generate valuable scientific datasets of unprecedented size.
   More information about Folding@home's COVID-19 research activities at the
   [Folding@home COVID-19 page](https://foldingathome.org/diseases/infectious-diseases/covid-19/).
-
-
   In addition to working directly with experimental collaborators and rapidly sharing
   new research findings through preprint servers, Folding@home has joined other
   researchers in committing to [rapidly share all COVID-19 research data](https://doi.org/10.1021/acs.jcim.0c00319),
@@ -32,25 +28,6 @@ Description: >
   indexing these massive datsets via the [MolSSI COVID-19 Molecular Structure and Therapeutics Hub](https://covid.molssi.org/).
   This repository contains several major datasets from this effort and comprises
   the single largest collection of molecular simulation data ever released.
-
-
-  The following datasets are available at this time:
-
-
-  **SARS-CoV-2 spike protein dataset:**
-  A 1.2 ms dataset of the SARS-CoV-2 spike protein.
-  [[MolSSI COVID Hub]](https://covid.molssi.org//simulations/#foldinghome-simulations-of-the-sars-cov-2-spike-protein-spike-spike-binding)
-
-
-  **SARS-CoV-2 main viral protease simulations:**
-  A 2.6 ms dataset of the SARS-CoV-2 main viral protease (apo, monomer).
-  [[MolSSI COVID Hub]](https://covid.molssi.org//simulations/#foldinghome-sars-cov-2-main-protease-apo-monomer-simulations-3clpro-3clpro-protease-activity)
-
-
-  **SARS-CoV-2 COVID Moonshot absolute free energy calculations:**
-  Absolute alchemical free energy calculations of crowdsourced molecule designs for the [COVID Moonshot](http://postera.ai/covid).
-  [[MolSSI COVID Hub]](https://covid.molssi.org//simulations/#foldinghome-expanded-ensemble-absolute-free-energy-calculations-of-potential-small-molecule-inhibitors-of-the-sars-cov-2-main-protease-from-the-covid-moonshot-3clpro-3clpro-protease-activity)
-
 Documentation: https://github.com/FoldingAtHome/coronavirus
 Contact: "[Folding@home](https://foldingathome.org/contact-us/)"
 ManagedBy: "[Folding@home](https://foldingathome.org)"
@@ -71,29 +48,36 @@ Tags:
   - structural biology
 License: "[CC0](https://creativecommons.org/share-your-work/public-domain/cc0/)"
 Resources:
-  - Description: <
-      Simulations of SARS-CoV-2 and associated host proteins, with emphasis on discovering druggable cryptic pockets.
+  - Description: Simulations of SARS-CoV-2 and associated host proteins, with emphasis on discovering druggable cryptic pockets, documented at the [MolSSI COVID Hub](https://covid.molssi.org//simulations/#foldinghome-simulations-of-the-sars-cov-2-spike-protein-spike-spike-binding).
     ARN: arn:aws:s3:::fah-public-data-covid19-cryptic-pockets
     Region: us-east-2
     Type: S3 Bucket
-  - Description: <
-      Absolute free energy calculations of small molecules from the [COVID Moonshot](http://postera.ai).
-      [[MolSSI COVID Hub]](https://covid.molssi.org//simulations/#trajectories-of-the-sars-cov-2-main-protease-protein-from-foldinghome-3clpro-nil)
+  - Description: Absolute free energy calculations of small molecules from the [COVID Moonshot](http://postera.ai), documented at the [MolSSI COVID Hub](https://covid.molssi.org//simulations/#foldinghome-expanded-ensemble-absolute-free-energy-calculations-of-potential-small-molecule-inhibitors-of-the-sars-cov-2-main-protease-from-the-covid-moonshot-3clpro-3clpro-protease-activity)
     ARN: arn:aws:s3:::fah-public-data-covid19-absolute-free-energy
     Region: us-east-2
     Type: S3 Bucket
-  - Description: <
-      Simulations of target proteins and bound small molecules from the [COVID Moonshot](http://postera.ai).
-      [[MolSSI COVID Hub]](https://covid.molssi.org//simulations/#trajectories-of-the-sars-cov-2-main-protease-protein-from-foldinghome-3clpro-nil)
+  - Description: Simulations of target proteins and bound small molecules from the [COVID Moonshot](http://postera.ai), documented at the [MolSSI COVID Hub](https://covid.molssi.org//simulations/#foldinghome-sars-cov-2-main-protease-apo-monomer-simulations-3clpro-3clpro-protease-activity)
     ARN: arn:aws:s3:::fah-public-data-covid19-moonshot-dynamics
     Region: us-east-2
     Type: S3 Bucket
 DataAtWork:
+  Tools & Applications:
+    - Title: SARS-CoV-2 spike protein dataset: A 1.2 ms dataset of the SARS-CoV-2 spike protein.
+      URL: https://covid.molssi.org//simulations/#foldinghome-simulations-of-the-sars-cov-2-spike-protein-spike-spike-binding
+      AuthorName: MolSSI COVID Molecular Structure and Therapeutics Hub
+      AuthorURL: https://covid.molssi.org
+    - Title: SARS-CoV-2 main viral protease simulations: A 2.6 ms dataset of the SARS-CoV-2 main viral protease (apo, monomer).
+      URL: https://covid.molssi.org//simulations/#foldinghome-sars-cov-2-main-protease-apo-monomer-simulations-3clpro-3clpro-protease-activity
+      AuthorName: MolSSI COVID Molecular Structure and Therapeutics Hub
+      AuthorURL: https://covid.molssi.org
+    - Title: SARS-CoV-2 COVID Moonshot absolute free energy calculations
+      URL: https://covid.molssi.org//simulations/#foldinghome-expanded-ensemble-absolute-free-energy-calculations-of-potential-small-molecule-inhibitors-of-the-sars-cov-2-main-protease-from-the-covid-moonshot-3clpro-3clpro-protease-activity
+      AuthorName: MolSSI COVID Molecular Structure and Therapeutics Hub
+      AuthorURL: https://covid.molssi.org
   Tutorials:
     - Title: "Folding@home COVID-19 efforts"
       URL: https://github.com/FoldingAtHome/coronavirus/blob/master/README.md
       AuthorName: "Folding@home Consortium"
-  Tools & Applications:
   Publications:
     - Title: Citizen Scientists Create an Exascale Computer to Combat COVID-19
       URL: https://www.biorxiv.org/content/10.1101/2020.06.27.175430v1

--- a/datasets/foldingathome-covid19.yaml
+++ b/datasets/foldingathome-covid19.yaml
@@ -39,7 +39,7 @@ Description: >
 
   **SARS-CoV-2 spike protein dataset:**
   A 1.2 ms dataset of the SARS-CoV-2 spike protein.
-  [[MolSSI COVID Hub]](https://covid.molssi.org//simulations/#foldinghome-simulations-of-the-sars-cov-2-spike-protein-spike-nil)
+  [[MolSSI COVID Hub]](https://covid.molssi.org//simulations/#foldinghome-simulations-of-the-sars-cov-2-spike-protein-spike-spike-binding)
 
 
   **SARS-CoV-2 main viral protease simulations:**
@@ -49,7 +49,7 @@ Description: >
 
   **SARS-CoV-2 COVID Moonshot absolute free energy calculations:**
   Absolute alchemical free energy calculations of crowdsourced molecule designs for the [COVID Moonshot](http://postera.ai/covid).
-  [[MolSSI COVID Hub]](https://covid.molssi.org//simulations/#foldinghome-expanded-ensemble-absolute-free-energy-calculations-of-potential-small-molecule-inhibitors-of-the-sars-cov-2-main-protease-from-the-covid-moonshot-3clpro-nil)
+  [[MolSSI COVID Hub]](https://covid.molssi.org//simulations/#foldinghome-expanded-ensemble-absolute-free-energy-calculations-of-potential-small-molecule-inhibitors-of-the-sars-cov-2-main-protease-from-the-covid-moonshot-3clpro-3clpro-protease-activity)
 
 Documentation: https://github.com/FoldingAtHome/coronavirus
 Contact: "[Folding@home](https://foldingathome.org/contact-us/)"

--- a/datasets/foldingathome-covid19.yaml
+++ b/datasets/foldingathome-covid19.yaml
@@ -62,7 +62,7 @@ Resources:
     Type: S3 Bucket
 DataAtWork:
   Tools & Applications:
-    - Title: SARS-CoV-2 spike protein dataset: A 1.2 ms dataset of the SARS-CoV-2 spike protein.
+    - Title: "SARS-CoV-2 spike protein dataset: A 1.2 ms dataset of the SARS-CoV-2 spike protein."
       URL: https://covid.molssi.org//simulations/#foldinghome-simulations-of-the-sars-cov-2-spike-protein-spike-spike-binding
       AuthorName: MolSSI COVID Molecular Structure and Therapeutics Hub
       AuthorURL: https://covid.molssi.org

--- a/datasets/foldingathome-covid19.yaml
+++ b/datasets/foldingathome-covid19.yaml
@@ -50,20 +50,18 @@ Contact: "[Folding@home](https://foldingathome.org/contact-us/)"
 ManagedBy: "[Folding@home](https://foldingathome.org)"
 UpdateFrequency: Datasets will be updated periodically as additional simulations are completed.
 Tags:
+  - alchemical free energy calculations
   - aws-pds
+  - biomolecular modeling
+  - coronavirus
   - COVID-19
   - foldingathome
-  - SARS-CoV-2
-  - coronavirus
-  - simulations
   - health
   - life sciences
-  - protein
-  - biomolecular simulations
   - molecular dynamics
-  - alchemical free energy calculations
-  - absolute free energy calculations
-  - relative free energy calculations
+  - protein
+  - SARS-CoV-2
+  - simulations
   - structural biology
 License: "[CC0](https://creativecommons.org/share-your-work/public-domain/cc0/)"
 Resources:

--- a/datasets/foldingathome-covid19.yaml
+++ b/datasets/foldingathome-covid19.yaml
@@ -52,7 +52,7 @@ UpdateFrequency: Datasets will be updated periodically as additional simulations
 Tags:
   - aws-pds
   - COVID-19
-  - Folding@home
+  - "Folding@home"
   - SARS-CoV-2
   - coronavirus
   - simulations

--- a/tags.yaml
+++ b/tags.yaml
@@ -1,6 +1,7 @@
 - aerial imagery
 - agriculture
 - air quality
+- alchemical free energy calculations
 - amino acid
 - analytics
 - array tomography
@@ -15,6 +16,7 @@
 - biodiversity
 - bioinformatics
 - biology
+- biomolecular modeling
 - bitcoin
 - blockchain
 - broadband
@@ -71,6 +73,7 @@
 - fast5
 - financial markets
 - fluorescence imaging
+- foldingathome
 - food security
 - free software
 - global
@@ -122,6 +125,7 @@
 - model
 - molecule
 - molecular docking
+- molecular dynamics
 - Mus musculus
 - movies
 - multimedia
@@ -156,6 +160,7 @@
 - regulatory
 - robotics
 - SARS
+- SARS-CoV-2
 - satellite imagery
 - segmentation
 - seismology
@@ -175,6 +180,7 @@
 - sports
 - statistics
 - STRIDES
+- structural biology
 - structural birth defect
 - subtitles
 - survey


### PR DESCRIPTION
@chueatwork : This PR fixes some formatting issues with the previous PR. The Description was not rendering markdown correctly, in that no paragraph breaks or boldface was showing up. These have been removed and the specific links to datasets have been moved to `Tools & Applications` within `DataAtWork:`. Hopefully, this will work better!

Apologies for the numerous PRs---we have an expanded list coming tomorrow.