### PR TITLE
Update Folding@home public datasets

### DIFF
--- a/datasets/foldingathome-covid19.yaml
+++ b/datasets/foldingathome-covid19.yaml
@@ -30,7 +30,7 @@ Description: >
   the single largest collection of molecular simulation data ever released.
 Documentation: https://github.com/FoldingAtHome/coronavirus
 Contact: "[Folding@home](https://foldingathome.org/contact-us/)"
-ManagedBy: "[Folding@home](https://foldingathome.org)"
+ManagedBy: "[Folding@home](https://foldingathome.org) // The [Folding@home Consortium](https://foldingathome.org/about/the-foldinghome-consortium/)"
 UpdateFrequency: Datasets will be updated periodically as additional simulations are completed.
 Tags:
   - alchemical free energy calculations
@@ -62,16 +62,20 @@ Resources:
     Type: S3 Bucket
 DataAtWork:
   Tools & Applications:
-    - Title: "SARS-CoV-2 spike protein dataset: A 1.2 ms dataset of the SARS-CoV-2 spike protein."
+    - Title: "SARS-CoV-2 spike protein dataset: A 1.2 ms dataset of the SARS-CoV-2 spike protein"
       URL: https://covid.molssi.org//simulations/#foldinghome-simulations-of-the-sars-cov-2-spike-protein-spike-spike-binding
       AuthorName: MolSSI COVID Molecular Structure and Therapeutics Hub
       AuthorURL: https://covid.molssi.org
-    - Title: "SARS-CoV-2 main viral protease simulations: A 2.6 ms dataset of the SARS-CoV-2 main viral protease (apo, monomer)."
+    - Title: "SARS-CoV-2 main viral protease simulations: A 2.6 ms dataset of the SARS-CoV-2 main viral protease (apo, monomer)"
       URL: https://covid.molssi.org//simulations/#foldinghome-sars-cov-2-main-protease-apo-monomer-simulations-3clpro-3clpro-protease-activity
       AuthorName: MolSSI COVID Molecular Structure and Therapeutics Hub
       AuthorURL: https://covid.molssi.org
     - Title: "SARS-CoV-2 COVID Moonshot absolute free energy calculations"
       URL: https://covid.molssi.org//simulations/#foldinghome-expanded-ensemble-absolute-free-energy-calculations-of-potential-small-molecule-inhibitors-of-the-sars-cov-2-main-protease-from-the-covid-moonshot-3clpro-3clpro-protease-activity
+      AuthorName: MolSSI COVID Molecular Structure and Therapeutics Hub
+      AuthorURL: https://covid.molssi.org
+    - Title: "SARS-CoV-2 nsp10 dataset: A 6.1 ms dataset of the SARS-CoV-2 nsp10 protein"
+      URL: https://covid.molssi.org//simulations/#foldinghome-simulations-of-nsp10-nsp10-nil
       AuthorName: MolSSI COVID Molecular Structure and Therapeutics Hub
       AuthorURL: https://covid.molssi.org
   Tutorials:

--- a/datasets/foldingathome-covid19.yaml
+++ b/datasets/foldingathome-covid19.yaml
@@ -62,30 +62,54 @@ Resources:
     Type: S3 Bucket
 DataAtWork:
   Tools & Applications:
-    - Title: "SARS-CoV-2 spike protein dataset: A 1.2 ms dataset of the SARS-CoV-2 spike protein"
-      URL: https://covid.molssi.org//simulations/#foldinghome-simulations-of-the-sars-cov-2-spike-protein-spike-spike-binding
-      AuthorName: MolSSI COVID Molecular Structure and Therapeutics Hub
-      AuthorURL: https://covid.molssi.org
-    - Title: "SARS-CoV-2 main viral protease (Mpro, 3CLPro, nsp5) simulations: A 2.6 ms dataset of the SARS-CoV-2 main viral protease (apo, monomer)"
+    - Title: "SARS-CoV-2 main viral protease (Mpro, 3CLPro, nsp5) monomer simulations: A 2.6 ms equilibrium dataset of the SARS-CoV-2 main viral protease (apo, monomer)"
       URL: https://covid.molssi.org//simulations/#foldinghome-sars-cov-2-main-protease-apo-monomer-simulations-3clpro-3clpro-protease-activity
-      AuthorName: MolSSI COVID Molecular Structure and Therapeutics Hub
-      AuthorURL: https://covid.molssi.org
+      AuthorName: "The Chodera lab at MSKCC"
+      AuthorURL: https://choderalab.org
     - Title: "SARS-CoV-2 COVID Moonshot absolute free energy calculations"
       URL: https://covid.molssi.org//simulations/#foldinghome-expanded-ensemble-absolute-free-energy-calculations-of-potential-small-molecule-inhibitors-of-the-sars-cov-2-main-protease-from-the-covid-moonshot-3clpro-3clpro-protease-activity
-      AuthorName: MolSSI COVID Molecular Structure and Therapeutics Hub
-      AuthorURL: https://covid.molssi.org
-    - Title: "SARS-CoV-2 nsp10 dataset: A 6.1 ms dataset of the SARS-CoV-2 nsp10 protein"
+      AuthorName: "The Voelz lab at Temple University"
+      AuthorURL: http://www.voelzlab.org/
+    - Title: "SARS-CoV-2 spike protein dataset: A 1.2 ms dataset of the SARS-CoV-2 spike protein in search of cryptic pockets"
+      URL: https://covid.molssi.org//simulations/#foldinghome-simulations-of-the-sars-cov-2-spike-protein-spike-spike-binding
+      AuthorName: "The Bowman lab at Washington University in St. Louis"
+      AuthorURL: https://bowmanlab.biochem.wustl.edu
+    - Title: "SARS-CoV-2 nsp10 dataset: A 6.1 ms dataset of the SARS-CoV-2 nsp10 protein in search of cryptic pockets"
       URL: https://covid.molssi.org//simulations/#foldinghome-simulations-of-nsp10-nsp10-nil
-      AuthorName: MolSSI COVID Molecular Structure and Therapeutics Hub
-      AuthorURL: https://covid.molssi.org
-    - Title: "SARS-CoV-2 RNA polymerase (nsp12, RdRP) dataset: A 3.4 ms dataset of the SARS-CoV-2 nsp12 protein"
+      AuthorName: "The Bowman lab at Washington University in St. Louis"
+      AuthorURL: https://bowmanlab.biochem.wustl.edu
+    - Title: "SARS-CoV-2 RNA polymerase (nsp12, RdRP) dataset: A 3.4 ms dataset of the SARS-CoV-2 nsp12 protein in search of cryptic pockets"
       URL: https://covid.molssi.org//simulations/#foldinghome-simulations-of-nsp12-rdrp-nil
-      AuthorName: MolSSI COVID Molecular Structure and Therapeutics Hub
-      AuthorURL: https://covid.molssi.org
-    - Title: "SARS-CoV-2 macrodomain (nsp3) dataset: An 11 ms dataset of the SARS-CoV-2 nsp3 protein"
+      AuthorName: "The Bowman lab at Washington University in St. Louis"
+      AuthorURL: https://bowmanlab.biochem.wustl.edu
+    - Title: "SARS-CoV-2 nsp3 macrodomain dataset: An 11 ms dataset of the SARS-CoV-2 nsp3 macrodomain in search of cryptic pockets"
       URL: https://covid.molssi.org//simulations/#foldinghome-simulations-of-nsp3-macrodomain-macrodomain-host-immune-response
-      AuthorName: MolSSI COVID Molecular Structure and Therapeutics Hub
-      AuthorURL: https://covid.molssi.org
+      AuthorName: "The Bowman lab at Washington University in St. Louis"
+      AuthorURL: https://bowmanlab.biochem.wustl.edu
+    - Title: "SARS-CoV-2 nsp3 pl2pro domain dataset: An 731 µs dataset of the SARS-CoV-2 nsp3 pl2pro domain in search of cryptic pockets"
+      URL: https://covid.molssi.org//simulations/#foldinghome-simulations-of-nsp3-pl2pro-domain-plpro-plpro-protease-activity
+      AuthorName: "The Bowman lab at Washington University in St. Louis"
+      AuthorURL: https://bowmanlab.biochem.wustl.edu
+    - Title: "SARS-CoV-2 main viral protease (Mpro, 3CLPro, nsp5) monomer simulations: A 6.4 ms dataset of the SARS-CoV-2 main viral protease (apo, monomer) in search of cryptic pockets"
+      URL: https://covid.molssi.org//simulations/#foldinghome-simulations-of-nsp5-3clpro-3clpro-protease-activity
+      AuthorName: "The Bowman lab at Washington University in St. Louis"
+      AuthorURL: https://bowmanlab.biochem.wustl.edu
+    - Title: "SARS-CoV-2 main viral protease (Mpro, 3CLPro, nsp5) dimer simulations: A 2.9 ms dataset of the SARS-CoV-2 main viral protease (apo, dimer) in search of cryptic pockets"
+      URL: https://covid.molssi.org//simulations/#foldinghome-simulations-of-nsp5-3clpro-3clpro-protease-activity
+      AuthorName: "The Bowman lab at Washington University in St. Louis"
+      AuthorURL: https://bowmanlab.biochem.wustl.edu
+    - Title: "SARS-CoV-2 nsp7 simulations: A 3.7 ms dataset of the SARS-CoV-2 nsp7 protein in search of cryptic pockets"
+      URL: https://covid.molssi.org//simulations/#foldinghome-simulations-of-nsp7-nsp7-nil
+      AuthorName: "The Bowman lab at Washington University in St. Louis"
+      AuthorURL: https://bowmanlab.biochem.wustl.edu
+    - Title: "SARS-CoV-2 nsp8 simulations: A 1.8 ms dataset of the SARS-CoV-2 nsp8 protein in search of cryptic pockets"
+      URL: https://covid.molssi.org//simulations/#foldinghome-simulations-of-nsp8-nsp8-nil
+      AuthorName: "The Bowman lab at Washington University in St. Louis"
+      AuthorURL: https://bowmanlab.biochem.wustl.edu
+    - Title: "SARS-CoV-2 nsp9 simulations: A 9 ms dataset of the SARS-CoV-2 nsp9 protein in search of cryptic pockets"
+      URL: https://covid.molssi.org//simulations/#foldinghome-simulations-of-nsp9-nsp9-nil
+      AuthorName: "The Bowman lab at Washington University in St. Louis"
+      AuthorURL: https://bowmanlab.biochem.wustl.edu
   Tutorials:
     - Title: "Folding@home COVID-19 efforts"
       URL: https://github.com/FoldingAtHome/coronavirus/blob/master/README.md

--- a/datasets/foldingathome-covid19.yaml
+++ b/datasets/foldingathome-covid19.yaml
@@ -82,6 +82,10 @@ DataAtWork:
       URL: https://covid.molssi.org//simulations/#foldinghome-simulations-of-nsp12-rdrp-nil
       AuthorName: MolSSI COVID Molecular Structure and Therapeutics Hub
       AuthorURL: https://covid.molssi.org
+    - Title: "SARS-CoV-2 macrodomain (nsp3) dataset: An 11 ms dataset of the SARS-CoV-2 nsp3 protein"
+      URL: https://covid.molssi.org//simulations/#foldinghome-simulations-of-nsp3-macrodomain-macrodomain-host-immune-response
+      AuthorName: MolSSI COVID Molecular Structure and Therapeutics Hub
+      AuthorURL: https://covid.molssi.org
   Tutorials:
     - Title: "Folding@home COVID-19 efforts"
       URL: https://github.com/FoldingAtHome/coronavirus/blob/master/README.md

--- a/datasets/foldingathome-covid19.yaml
+++ b/datasets/foldingathome-covid19.yaml
@@ -66,7 +66,7 @@ DataAtWork:
       URL: https://covid.molssi.org//simulations/#foldinghome-simulations-of-the-sars-cov-2-spike-protein-spike-spike-binding
       AuthorName: MolSSI COVID Molecular Structure and Therapeutics Hub
       AuthorURL: https://covid.molssi.org
-    - Title: "SARS-CoV-2 main viral protease simulations: A 2.6 ms dataset of the SARS-CoV-2 main viral protease (apo, monomer)"
+    - Title: "SARS-CoV-2 main viral protease (Mpro, 3CLPro, nsp5) simulations: A 2.6 ms dataset of the SARS-CoV-2 main viral protease (apo, monomer)"
       URL: https://covid.molssi.org//simulations/#foldinghome-sars-cov-2-main-protease-apo-monomer-simulations-3clpro-3clpro-protease-activity
       AuthorName: MolSSI COVID Molecular Structure and Therapeutics Hub
       AuthorURL: https://covid.molssi.org
@@ -78,7 +78,7 @@ DataAtWork:
       URL: https://covid.molssi.org//simulations/#foldinghome-simulations-of-nsp10-nsp10-nil
       AuthorName: MolSSI COVID Molecular Structure and Therapeutics Hub
       AuthorURL: https://covid.molssi.org
-    - Title: "SARS-CoV-2 nsp12 dataset: A 3.4 ms dataset of the SARS-CoV-2 nsp12 protein"
+    - Title: "SARS-CoV-2 RNA polymerase (nsp12, RdRP) dataset: A 3.4 ms dataset of the SARS-CoV-2 nsp12 protein"
       URL: https://covid.molssi.org//simulations/#foldinghome-simulations-of-nsp12-rdrp-nil
       AuthorName: MolSSI COVID Molecular Structure and Therapeutics Hub
       AuthorURL: https://covid.molssi.org

--- a/datasets/foldingathome-covid19.yaml
+++ b/datasets/foldingathome-covid19.yaml
@@ -78,6 +78,10 @@ DataAtWork:
       URL: https://covid.molssi.org//simulations/#foldinghome-simulations-of-nsp10-nsp10-nil
       AuthorName: MolSSI COVID Molecular Structure and Therapeutics Hub
       AuthorURL: https://covid.molssi.org
+    - Title: "SARS-CoV-2 nsp12 dataset: A 3.4 ms dataset of the SARS-CoV-2 nsp12 protein"
+      URL: https://covid.molssi.org//simulations/#foldinghome-simulations-of-nsp12-rdrp-nil
+      AuthorName: MolSSI COVID Molecular Structure and Therapeutics Hub
+      AuthorURL: https://covid.molssi.org
   Tutorials:
     - Title: "Folding@home COVID-19 efforts"
       URL: https://github.com/FoldingAtHome/coronavirus/blob/master/README.md

--- a/datasets/foldingathome-covid19.yaml
+++ b/datasets/foldingathome-covid19.yaml
@@ -83,6 +83,6 @@ DataAtWork:
       URL: https://github.com/FoldingAtHome/coronavirus/blob/master/README.md
       AuthorName: "Folding@home Consortium"
   Publications:
-    - Title: Citizen Scientists Create an Exascale Computer to Combat COVID-19
-      URL: https://www.biorxiv.org/content/10.1101/2020.06.27.175430v1
-      AuthorName: Maxwell I. Zimmerman, Justin R. Porter, Michael D. Ward, Sukrit Singh, Neha Vithani, Artur Meller, et al.
+    - Title: "SARS-CoV-2 Simulations Go Exascale to Capture Spike Opening and Reveal Cryptic Pockets Across the Proteome"
+      URL: https://doi.org/10.1101/2020.06.27.175430
+      AuthorName: "Maxwell I. Zimmerman, Justin R. Porter, Michael D. Ward, Sukrit Singh, Neha Vithani, Artur Meller, Upasana L. Mallimadugula, Catherine E. Kuhn, Jonathan H. Borowsky,  View ORCID ProfileRafal P. Wiewiora, Matthew F. D. Hurley, Aoife M Harbison, Carl A Fogarty, Joseph E. Coffland, Elisa Fadda, Vincent A. Voelz, John D. Chodera, Gregory R. Bowman"


### PR DESCRIPTION
This PR adds the remainder of the [Folding@home](http://foldingathome.org) cryptic pocket datasets associated with the [bioRxiv preprint](https://doi.org/10.1101/2020.06.27.175430), which collectively add another 45 ms of simulation data.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
