### PR TITLE
bug in bucket name for EPT files

### DIFF
--- a/datasets/usgs-lidar.yaml
+++ b/datasets/usgs-lidar.yaml
@@ -17,7 +17,7 @@ Tags:
   - sustainability
 License: US Government Public Domain https://www.usgs.gov/faqs/what-are-terms-uselicensing-map-services-and-data-national-map
 Resources:
-  - Description: Public access Entwine Point Tiles of most resources from the ``arn:aws:s3:::usgs-lidar`` bucket.
+  - Description: Public access Entwine Point Tiles of most resources from the ``arn:aws:s3:::usgs-lidar-public`` bucket.
     ARN: arn:aws:s3:::usgs-lidar-public
     Region: us-west-2
     Type: S3 Bucket


### PR DESCRIPTION
ETP files are in usgs-lidar-public, not usgs-lidar.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
