### PR TITLE
Terrain Tiles: Update URLs and add usage example

### DIFF
--- a/datasets/terrain-tiles.yaml
+++ b/datasets/terrain-tiles.yaml
@@ -1,6 +1,6 @@
 Name: Terrain Tiles
 Description: A global dataset providing bare-earth terrain heights, tiled for easy usage and provided on S3.
-Documentation: https://mapzen.com/documentation/terrain-tiles/
+Documentation: https://github.com/tilezen/joerd/tree/master/docs
 Contact: https://github.com/tilezen/joerd/issues
 UpdateFrequency: New data is added based on community feedback
 Collabs:
@@ -14,7 +14,7 @@ Tags:
   - geospatial
   - sustainability
   - disaster response
-License: https://mapzen.com/terms/
+License: https://github.com/tilezen/joerd/blob/master/docs/attribution.md
 Resources:
   - Description: Gridded elevation tiles
     ARN: arn:aws:s3:::elevation-tiles-prod
@@ -59,4 +59,8 @@ DataAtWork:
       URL: https://podpac.org/datasets.html#terraintiles
       AuthorName: Creare
       AuthorURL: http://www.creare.com/
+    - Title: "Terradactile: Generate DEM and hillshade Cloud Optimized GeoTIFFs for visualization and download based on terrain tiles"
+      URL: https://terradactile.sparkgeo.com/
+      AuthorName: Sparkgeo
+      AuthorURL: https://sparkgeo.com/
   Publications:


### PR DESCRIPTION
*Issue #, if available:* Did not create an issue. I can create an issue if required.

*Description of changes:*
Some of the links in the Terrain Tiles registry page are outdated and are either not as relevant as other existing documentation or are redirect to a github repo. Summary of changes:
- Former 'Documentation' link redirected to the new [URL](https://github.com/tilezen/joerd/tree/master/docs).
- 'License' link went to Mapzen TOCs. This was not relevant to Terrain Tiles. Update to this [URL](https://github.com/tilezen/joerd/blob/master/docs/attribution.md) with attribution info.

A new application has also been added under Usage Examples: [Terradactile](https://terradactile.sparkgeo.com/).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
