### PR TITLE
Add Allen Cell Single-cell Image Dataset entry

### DIFF
--- a/datasets/allen-cell-imaging-collections.yaml
+++ b/datasets/allen-cell-imaging-collections.yaml
@@ -61,6 +61,10 @@ DataAtWork:
       URL: https://imsc.allencell.org
       AuthorName: Allen Institute for Cell Science
       AuthorURL: https://www.alleninstitute.org/what-we-do/cell-science/about/team/
+    - Title: AICS hiPSC Single-cell Image Dataset (embargoed until 07 Dec 2020)
+      URL: https://www.allencell.org/
+      AuthorName: Allen Institute for Cell Science
+      AuthorURL: https://www.alleninstitute.org/what-we-do/cell-science/about/team/
   Tutorials:
     - Title: Download and train label-free models
       URL: https://github.com/AllenCellModeling/pytorch_fnet/blob/master/examples/download_and_train.py


### PR DESCRIPTION
Add entry for currently embargoed Allen Institute for Cell Science Single-cell Image Dataset.  Embargo expires on 12/7/2020, will follow up with a second PR then.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
