### PR TITLE
Add Folding@home therapeutic antibody simulations S3 bucket and new ACE2:RBD dataset

### DIFF
--- a/datasets/foldingathome-covid19.yaml
+++ b/datasets/foldingathome-covid19.yaml
@@ -31,7 +31,7 @@ Description: >
   the single largest collection of molecular simulation data ever released.
 Documentation: https://github.com/FoldingAtHome/coronavirus
 Contact: "[Folding@home](https://foldingathome.org/contact-us/)"
-ManagedBy: "The Folding@home Consortium"
+ManagedBy: "Folding@home"
 UpdateFrequency: Datasets will be updated periodically as additional simulations are completed.
 Tags:
   - alchemical free energy calculations

--- a/datasets/foldingathome-covid19.yaml
+++ b/datasets/foldingathome-covid19.yaml
@@ -31,7 +31,7 @@ Description: >
   the single largest collection of molecular simulation data ever released.
 Documentation: https://github.com/FoldingAtHome/coronavirus
 Contact: "[Folding@home](https://foldingathome.org/contact-us/)"
-ManagedBy: "[Folding@home](https://foldingathome.org) // The [Folding@home Consortium](https://foldingathome.org/about/the-foldinghome-consortium/)"
+ManagedBy: "The Folding@home Consortium"
 UpdateFrequency: Datasets will be updated periodically as additional simulations are completed.
 Tags:
   - alchemical free energy calculations

--- a/datasets/foldingathome-covid19.yaml
+++ b/datasets/foldingathome-covid19.yaml
@@ -26,6 +26,7 @@ Description: >
   [Molecular Sciences Software Institute (MolSSI)](http://molssi.org) to share datasets of unprecented side
   through the [AWS Open Data Registry](https://registry.opendata.aws/),
   indexing these massive datsets via the [MolSSI COVID-19 Molecular Structure and Therapeutics Hub](https://covid.molssi.org/).
+  The complete index of all Folding@home datasets can be found [here](https://covid.molssi.org//org-contributions/#folding--home).
   This repository contains several major datasets from this effort and comprises
   the single largest collection of molecular simulation data ever released.
 Documentation: https://github.com/FoldingAtHome/coronavirus
@@ -50,6 +51,10 @@ License: "[CC0](https://creativecommons.org/share-your-work/public-domain/cc0/)"
 Resources:
   - Description: Simulations of SARS-CoV-2 and associated host proteins, with emphasis on discovering druggable cryptic pockets, documented at the [MolSSI COVID Hub](https://covid.molssi.org//simulations/#foldinghome-simulations-of-the-sars-cov-2-spike-protein-spike-spike-binding).
     ARN: arn:aws:s3:::fah-public-data-covid19-cryptic-pockets
+    Region: us-east-2
+    Type: S3 Bucket
+  - Description: Simulations of SARS-CoV-2 and associated host proteins relevant to neutralization by therapeutic antibodies, documented at the [MolSSI COVID Hub](https://covid.molssi.org//simulations/#foldinghome-simulations-of-the-sars-cov-2-spike-rbd-bound-to-human-ace2).
+    ARN: arn:aws:s3:::fah-public-data-covid19-antibodies
     Region: us-east-2
     Type: S3 Bucket
   - Description: Absolute free energy calculations of small molecules from the [COVID Moonshot](http://postera.ai), documented at the [MolSSI COVID Hub](https://covid.molssi.org//simulations/#foldinghome-expanded-ensemble-absolute-free-energy-calculations-of-potential-small-molecule-inhibitors-of-the-sars-cov-2-main-protease-from-the-covid-moonshot-3clpro-3clpro-protease-activity)
@@ -110,6 +115,10 @@ DataAtWork:
       URL: https://covid.molssi.org//simulations/#foldinghome-simulations-of-nsp9-nsp9-nil
       AuthorName: "The Bowman lab at Washington University in St. Louis"
       AuthorURL: https://bowmanlab.biochem.wustl.edu
+    - Title: "SARS-CoV-2 spike RBD bound to human ACE2 receptor (173.8 us): Wild-type and mutant simulations"
+      URL: https://covid.molssi.org//simulations/#foldinghome-simulations-of-the-sars-cov-2-spike-rbd-bound-to-human-ace2
+      AuthorName: "The Chodera lab at the Memorial Sloan Kettering Cancer Center"
+      AuthorURL: https://choderalab.org
   Tutorials:
     - Title: "Folding@home COVID-19 efforts"
       URL: https://github.com/FoldingAtHome/coronavirus/blob/master/README.md


### PR DESCRIPTION
@chueatwork : This PR adds another S3 bucket (focused on datasets related to therapeutic antibodies for COVID-19) and a new ACE2:RBD simulation dataset associated with a forthcoming paper.

We also now add a link to the [master index of all Folding@home simulation datasets](https://covid.molssi.org//org-contributions/#folding--home) on the AWS Open Data Registry at the [MolSSI COVID-19 Molecular Structure and Therapeutics Hub](http://covid.molssi.org).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
