### PR TITLE
Added link to GOES-2-go Python package

### DIFF
--- a/datasets/noaa-goes.yaml
+++ b/datasets/noaa-goes.yaml
@@ -64,9 +64,9 @@ DataAtWork:
       AuthorName: Peter Schmiedeskamp
   Tools & Applications:
     - Title: GOES-2-go is a python package for downloading and plotting plotting GOES data.
-    - URL: https://github.com/blaylockbk/goes2go
-    - AuthorName: Brian K. Blaylock
-    - AuthorURL: https://www.linkedin.com/in/blaylockbk/
+      URL: https://github.com/blaylockbk/goes2go
+      AuthorName: Brian K. Blaylock
+      AuthorURL: https://www.linkedin.com/in/blaylockbk/
   Publications:
     - Title: Observations of lightning in relation to transitions in volcanic activity during the 3 June 2018 Fuego Eruption
       URL: https://www.nature.com/articles/s41598-020-74576-x

--- a/datasets/noaa-goes.yaml
+++ b/datasets/noaa-goes.yaml
@@ -63,6 +63,10 @@ DataAtWork:
       URL: https://github.com/awslabs/amazon-asdi/tree/master/examples/goes16-precip-julia
       AuthorName: Peter Schmiedeskamp
   Tools & Applications:
+    - Title: GOES-2-go is a python package for downloading and plotting plotting GOES data.
+    - URL: https://github.com/blaylockbk/goes2go
+    - AuthorName: Brian K. Blaylock
+    - AuthorURL: https://www.linkedin.com/in/blaylockbk/
   Publications:
     - Title: Observations of lightning in relation to transitions in volcanic activity during the 3 June 2018 Fuego Eruption
       URL: https://www.nature.com/articles/s41598-020-74576-x


### PR DESCRIPTION
The GOES-2-go python package helps a user download GOES data from the AWS buckets and also includes recipes for ABI RGB products.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
