### PR TITLE
Added a tutorial link to a python package

### DIFF
--- a/datasets/noaa-hrrr-pds.yaml
+++ b/datasets/noaa-hrrr-pds.yaml
@@ -51,4 +51,7 @@ DataAtWork:
     - Title: Conda Enironment Setup Guide
       URL: https://mesowest.utah.edu/html/hrrr/zarr_documentation/conda_environment.html
       AuthorName: Zach Rieck
+    - Title: HRRR-B Python package: download and read HRRR grib2 files
+      URL: https://github.com/blaylockbk/HRRR_archive_download
+      AuthorName: Brian Blaylock
 

--- a/datasets/noaa-hrrr-pds.yaml
+++ b/datasets/noaa-hrrr-pds.yaml
@@ -51,7 +51,7 @@ DataAtWork:
     - Title: Conda Enironment Setup Guide
       URL: https://mesowest.utah.edu/html/hrrr/zarr_documentation/conda_environment.html
       AuthorName: Zach Rieck
-    - Title: HRRR-B Python package: download and read HRRR grib2 files
+    - Title: "HRRR-B Python package: download and read HRRR grib2 files"
       URL: https://github.com/blaylockbk/HRRR_archive_download
       AuthorName: Brian Blaylock
 


### PR DESCRIPTION
When people ask me how to get and read the HRRR grib2 files, I point them to this package. It can download HRRR files from Amazon, Google, NOMADS, and Pando. Can download full files or do a range-get to download specific GRIB fields.  Also, can read the file with xarray/cfgrib.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
