### PR TITLE
Fix broken T&C link 

### DIFF
--- a/datasets/sorel-20m.yaml
+++ b/datasets/sorel-20m.yaml
@@ -20,7 +20,7 @@ Tags:
   - deep learning
   - labeled
   - machine learning
-License: See Terms of Use at "https://github.com/sophos-ai/SOREL-20M/blob/master/Terms%20and%20Conditions%20of%20Use.pdf"
+License: See Terms of Use at https://github.com/sophos-ai/SOREL-20M/blob/master/Terms%20and%20Conditions%20of%20Use.pdf
 Resources:
   - Description: Sophos/ReversingLabs 20 million sample dataset
     ARN: arn:aws:s3:::sorel-20m/

--- a/datasets/sorel-20m.yaml
+++ b/datasets/sorel-20m.yaml
@@ -20,7 +20,7 @@ Tags:
   - deep learning
   - labeled
   - machine learning
-License: See Terms of Use at https://github.com/sophos-ai/SOREL-20M/blob/master/Terms%20and%20Conditions%20of%20Use.pdf
+License: See the [Terms of Use](https://github.com/sophos-ai/SOREL-20M/blob/master/Terms%20and%20Conditions%20of%20Use.pdf)
 Resources:
   - Description: Sophos/ReversingLabs 20 million sample dataset
     ARN: arn:aws:s3:::sorel-20m/


### PR DESCRIPTION
This pull request (hopefully finally) fixes the formatting on the terms and conditions link.  Apologies for the thrash.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
