### PR TITLE
Replaced the Documentation Link in Radarsat-1 YAML file

### DIFF
--- a/datasets/radarsat-1.yaml
+++ b/datasets/radarsat-1.yaml
@@ -1,6 +1,6 @@
 Name: RADARSAT-1
 Description: Developed and operated by the Canadian Space Agency, it is Canada's first commercial Earth observation satellite.
-Documentation: https://mdacorporation.com/geospatial/international/satellites/RADARSAT-1/
+Documentation: https://www.asc-csa.gc.ca/eng/satellites/radarsat1/what-is-radarsat1.asp
 Contact: https://www.eodms-sgdot.nrcan-rncan.gc.ca
 ManagedBy: "[Natural Resources Canada](https://nrcan.gc.ca/)"
 UpdateFrequency: The initial product release includes the 36000 products originally ordered by the Government of Canada. Products are added on an adhoc basis driven by prioritized foreign repatriation efforts and new processing orders from the raw archive.


### PR DESCRIPTION
Replaced the Documentation Link in Radarsat-1 YAML file

*Issue #, if available:* n/a

*Description of changes:*
The original Documentation link to MDA no longer exists. A new link has been provided to a Government of Canada page.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
