### PR TITLE
Differentiated COG and CSV data files

### DIFF
--- a/datasets/dataforgood-fb-hrsl.yaml
+++ b/datasets/dataforgood-fb-hrsl.yaml
@@ -34,8 +34,12 @@ License: |
   Settlement Layer (HRSL). Source imagery for HRSL © 2016 [DigitalGlobe](http://explore.digitalglobe.com/Basemap-Vivid.html).
   Accessed DAY MONTH YEAR.
 Resources:
-  - Description: CSV and Cloud-optimized GeoTIFF files
-    ARN: arn:aws:s3:::dataforgood-fb-data
+  - Description: Cloud-optimized GeoTIFF files
+    ARN: arn:aws:s3:::dataforgood-fb-data/hrsl-cogs/
+    Region: us-east-1
+    Type: S3 Bucket
+  - Description: CSV files
+    ARN: arn:aws:s3:::dataforgood-fb-data/csv/
     Region: us-east-1
     Type: S3 Bucket
 DataAtWork:


### PR DESCRIPTION
*Issue #, if available:*

We’ve introduced a new path for cloud-optimized GeoTIFFs with HRSL content.

*Description of changes:*

This change introduces two resources, an S3 prefix with CSV data and another one with COG data.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
