### PR TITLE
Add links to the organizations backing UniProt

### DIFF
--- a/datasets/uniprot.yaml
+++ b/datasets/uniprot.yaml
@@ -1,8 +1,8 @@
 Name: UniProt
-Description: The Universal Protein Resource (UniProt) is a comprehensive resource for protein sequence and annotation data. The UniProt databases are the UniProt Knowledgebase (UniProtKB), the UniProt Reference Clusters (UniRef), and the UniProt Archive (UniParc). The UniProt consortium and host institutions EMBL-EBI, SIB and PIR are committed to the long-term preservation of the UniProt databases.
+Description: The Universal Protein Resource (UniProt) is a comprehensive resource for protein sequence and annotation data. The UniProt databases are the UniProt Knowledgebase (UniProtKB), the UniProt Reference Clusters (UniRef), and the UniProt Archive (UniParc). The UniProt consortium and host institutions [EMBL-EBI](https://www.ebi.ac.uk), [SIB Swiss Institute of Bioinformatics](https://www.sib.swiss) and [PIR](https://proteininformationresource.org/) are committed to the long-term preservation of the [UniProt](https://www.uniprot.org) databases.
 Contact: https://www.uniprot.org/contact
 Documentation: https://www.uniprot.org/help/about
-ManagedBy: Swiss Institute of Bioinformatics
+ManagedBy: "[SIB Swiss Institute of Bioinformatics](https://sp.sib.swiss/) on behalf of the [UniProt Consortium](https://www.uniprot.org/help/about)"
 UpdateFrequency: Under 1 months after a new UniProt release.
 Tags:  
   - aws-pds
@@ -30,5 +30,5 @@ DataAtWork:
   Tutorials:
     - Title: "UniProt SPARQL"
       URL: https://github.com/sib-swiss/sparql-training/tree/master/uniprot
-      AuthorName: Swiss-Prot Group at Swiss Institute of Bioinformatics
+      AuthorName: Swiss-Prot Group at SIB Swiss Institute of Bioinformatics
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* The UniProt consortium description now has links and managed by includes the phrase on behalf of.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
