### PR TITLE
Update noaa-ncn.yaml

### DIFF
--- a/datasets/noaa-ncn.yaml
+++ b/datasets/noaa-ncn.yaml
@@ -6,7 +6,7 @@ Description: |
       - [NOAA-NCN on AWS](https://noaa-cors-pds.s3.amazonaws.com/index.html)
       - [NCN https](https://geodesy.noaa.gov/corsdata/)
       - [NGS's customized data request service (UFCORS)](https://geodesy.noaa.gov/UFCORS/)
-      - [Anonymous ftp://geodesy.noaa.gov/cors/](ftp://geodesy.noaa.gov/cors/)
+      - [Anonymous ftp://geodesy.noaa.gov/cors/ and ftp://alt.ngs.noaa.gov/cors/ - *This service is going away in August 02, 2021!*](ftp://geodesy.noaa.gov/cors/)
   - #### NCN Data and Products
       - **RINEX**: The GPS/GNSS data collected at NCN stations are made available to the public by NGS in Receiver INdependent EXchange (RINEX) format. Most data are available within 1 hour (60 minutes) from when they were recorded at the remote site, and a few sites have a delay of 24 hours (1440 minutes).<br/>RINEX data can be found at: *rinex/`YYYY`/`DDD`/`ssss`/*
       - **Station logs**: 


### PR DESCRIPTION
*Issue #, if available:*
NOAA-NCN ftp services are going away in August 02, 2021.
*Description of changes:*
- Added notice about NOAA-NCN ftp services going away in August 02, 2021.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice. Thank you very much for your help!
