### PR TITLE
Update noaa-ufs-s2s.yaml

### DIFF
--- a/datasets/noaa-ufs-s2s.yaml
+++ b/datasets/noaa-ufs-s2s.yaml
@@ -1,4 +1,4 @@
-Name: NOAA Unified Forecast System Subseasonal to Seasonal Prototype 5
+Name: NOAA Unified Forecast System Subseasonal to Seasonal Prototypes 5 & 6
 Description: |
   The Unified Forecast System Subseasonal to Seasonal prototype 5 (UFS S2Sp5) dataset is reforecast data from the UFS atmosphere-ocean coupled model experimental prototype version 5 produced by the Medium Range and Subseasonal to Seasonal Application team of the UFS-R2O project. The UFS S2Sp5 is the first dataset released to the broader weather community for analysis and feedback as part of the development of the next generation operational numerical weather prediction system from NWS. The dataset includes all the major weather variables for atmosphere, land, ocean, sea ice, and ocean waves.
   <br/>
@@ -29,9 +29,9 @@ Tags:
 
 License: Open Data. There are no restrictions on the use of this data.
 Resources:
-  - Description: UFS prototype files
-    ARN: arn:aws:s3:::noaa-ufs-prototype5-pds
+  - Description: UFS prototype files (5 & 6)
+    ARN: arn:aws:s3:::noaa-ufs-prototypes-pds
     Region: us-east-1
     Type: S3 Bucket
     Explore:
-    - '[Browse Bucket](https://noaa-ufs-prototype5-pds.s3.amazonaws.com/index.html)'
+    - '[Browse Bucket](https://noaa-ufs-prototypes-pds.s3.amazonaws.com/index.html)'


### PR DESCRIPTION
Updated bucket names. Prototype 6 was added and the bucket name changed to noaa-ufs-prototypes-pds to include both prototypes.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
