### PR TITLE
Removing - Tutorial

### DIFF
--- a/datasets/nyc-tlc-trip-records-pds.yaml
+++ b/datasets/nyc-tlc-trip-records-pds.yaml
@@ -28,6 +28,9 @@ DataAtWork:
     - Title: Build a Real-time Stream Processing Pipeline with Apache Flink on AWS
       URL: https://aws.amazon.com/blogs/big-data/build-a-real-time-stream-processing-pipeline-with-apache-flink-on-aws/
       AuthorName: Steffen Hausmann
+    - Title: Exploring data with Python and Amazon S3 Select
+      URL: https://github.com/aws-samples/cloud-experiments/tree/master/experiments/notebooks/exploring-data
+      AuthorName: Manav Sehgal
     - Title: Optimizing data for analysis with Amazon Athena and AWS Glue
       URL: https://github.com/aws-samples/aws-open-data-analytics-notebooks/tree/master/optimizing-data
       AuthorName: Manav Sehgal


### PR DESCRIPTION
Hi guys,

Thanks for all your efforts in maintaining the Open-Data-Registry.

*Issue #, if available:*

*Description of changes:* Removing tutorial titled "Exploring data with Python and Amazon S3 Select" by Manav Sehgal as the link "https://github.com/aws-samples/cloud-experiments/tree/master/exploring-data" yields page not found (404).

Thanks again for your efforts! :)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
