### PR TITLE
Add NCAR CESM2-LE Dataset

### DIFF
--- a/datasets/ncar-cesm2-lens.yaml
+++ b/datasets/ncar-cesm2-lens.yaml
@@ -1,9 +1,9 @@
 Name: Community Earth System Model v2 Large Ensemble (CESM2 LENS)
 Description: >
-  The Community Earth System Model v2 (CESM2) Large Ensemble Numerical Simulation (CESM2-LE) dataset includes a 100-member ensemble of climate simulations for the period 1850-2100 assuming the SSP3.7 greenhouse gas concentration scenario (2015-2100). The data comprise both surface (2D) and volumetric (3D) variables in the atmosphere, ocean, land, and ice domains. The total data volume of the original dataset is ~4PB, which has traditionally been stored as ~4,000,000 individual CF/NetCDF files on disk or magnetic tape made available through the NCAR Climate Data Gateway for download or via web services.
-
-     NCAR has copied a subset (currently ~500 TB) of CESM2 LENS data to Amazon S3 as part of the AWS Public Datasets Program. To optimize for large-scale analytics we have represented the data as ~275 Zarr stores format accessible through the Python Xarray library. Each Zarr store contains a single physical variable for a given model run type and temporal frequency (monthly, daily, 6-hourly).
-Documentation: https://doi.org/10.26024/wt24-5j82
+  The US National Center for Atmospheric Research partnered with the IBS Center for Climate Physics in South Korea to generate the CESM2 Large Ensemble which consists of 100 ensemble members at 1 degree spatial resolution covering the period 1850-2100 under CMIP6 historical and SSP370 future radiative forcing scenarios. Data sets from this ensemble were made downloadable via the Climate Data Gateway on June 14th, 2021.
+  
+  NCAR has copied a subset (currently ~500 TB) of CESM2 LENS data to Amazon S3 as part of the AWS Public Datasets Program. To optimize for large-scale analytics we have represented the data as ~275 Zarr stores format accessible through the Python Xarray library. Each Zarr store contains a single physical variable for a given model run type and temporal frequency (monthly, daily).
+Documentation: https://doi.org/10.26024/y48t-q717
 Contact: cisl-aws-lens@ucar.edu
 ManagedBy: "[National Center for Atmospheric Research](https://ncar.ucar.edu/)"
 UpdateFrequency: Rare. The LENS experiment is complete, but we may occasionally copy additional fields from NCAR to AWS, or fix problems discovered in the AWS copy.
@@ -32,17 +32,13 @@ Resources:
     Type: S3 Bucket
 DataAtWork:
   Tools & Applications:
-    - Title: Jupyter Notebook and other documentation and tools for CESM LENS on AWS
+    - Title: Jupyter Notebook and other documentation and tools for CESM2-LE on AWS
       URL: https://github.com/NCAR/cesm2-le-aws
       AuthorName: NCAR Science at Scale team
     - Title: Rendered (static) version of Jupyter Notebook
-      URL: http://ncar-aws-www.s3-website-us-west-2.amazonaws.com/kay-et-al-2015.v2.html
+      URL: https://ncar.github.io/cesm2-le-aws/kay_et_al_lens2.html
       AuthorName: Maxwell Grover, NCAR
-  Tutorials:
-    - Title: Analyzing large climate model ensembles in the cloud
-      URL: https://medium.com/pangeo/cesm-lens-on-aws-4e2a996397a1
-      AuthorName: Joe Hamman, NCAR
   Publications:
-    - Title: "The Community Earth System Model (CESM) Large Ensemble Project: A Community Resource for Studying Climate Change in the Presence of Internal Climate Variability"
-      URL: https://doi.org/10.5065/d6j101d1
-      AuthorName: Kay et al. (2015), Bull. AMS, 96, 1333-1349
+    - Title: "Ubiquity of human-induced changes in climate variability"
+      URL: https://doi.org/10.5194/esd-2021-50
+      AuthorName: Rodgers et al. (2021), Earth Syst. Dynam., 12, 1–19, 2021

--- a/datasets/ncar-cesm2-lens.yaml
+++ b/datasets/ncar-cesm2-lens.yaml
@@ -1,0 +1,48 @@
+Name: Community Earth System Model v2 Large Ensemble (CESM2 LENS)
+Description: >
+  The Community Earth System Model v2 (CESM2) Large Ensemble Numerical Simulation (CESM2-LE) dataset includes a 100-member ensemble of climate simulations for the period 1850-2100 assuming the SSP3.7 greenhouse gas concentration scenario (2015-2100). The data comprise both surface (2D) and volumetric (3D) variables in the atmosphere, ocean, land, and ice domains. The total data volume of the original dataset is ~4PB, which has traditionally been stored as ~4,000,000 individual CF/NetCDF files on disk or magnetic tape made available through the NCAR Climate Data Gateway for download or via web services.
+
+     NCAR has copied a subset (currently ~500 TB) of CESM2 LENS data to Amazon S3 as part of the AWS Public Datasets Program. To optimize for large-scale analytics we have represented the data as ~275 Zarr stores format accessible through the Python Xarray library. Each Zarr store contains a single physical variable for a given model run type and temporal frequency (monthly, daily, 6-hourly).
+Documentation: https://doi.org/10.26024/wt24-5j82
+Contact: cisl-aws-lens@ucar.edu
+ManagedBy: "[National Center for Atmospheric Research](https://ncar.ucar.edu/)"
+UpdateFrequency: Rare. The LENS experiment is complete, but we may occasionally copy additional fields from NCAR to AWS, or fix problems discovered in the AWS copy.
+Collabs:
+  ASDI:
+    Tags:
+      - climate
+Tags:
+  - climate
+  - model
+  - climate model
+  - atmosphere
+  - oceans
+  - land
+  - ice
+  - geospatial
+  - machine learning
+  - aws-pds
+  - sustainability
+  - zarr
+License: https://www.ucar.edu/terms-of-use/data
+Resources:
+  - Description: Project data files
+    ARN: arn:aws:s3:::ncar-cesm2-lens
+    Region: us-west-2
+    Type: S3 Bucket
+DataAtWork:
+  Tools & Applications:
+    - Title: Jupyter Notebook and other documentation and tools for CESM LENS on AWS
+      URL: https://github.com/NCAR/cesm2-le-aws
+      AuthorName: NCAR Science at Scale team
+    - Title: Rendered (static) version of Jupyter Notebook
+      URL: http://ncar-aws-www.s3-website-us-west-2.amazonaws.com/kay-et-al-2015.v2.html
+      AuthorName: Maxwell Grover, NCAR
+  Tutorials:
+    - Title: Analyzing large climate model ensembles in the cloud
+      URL: https://medium.com/pangeo/cesm-lens-on-aws-4e2a996397a1
+      AuthorName: Joe Hamman, NCAR
+  Publications:
+    - Title: "The Community Earth System Model (CESM) Large Ensemble Project: A Community Resource for Studying Climate Change in the Presence of Internal Climate Variability"
+      URL: https://doi.org/10.5065/d6j101d1
+      AuthorName: Kay et al. (2015), Bull. AMS, 96, 1333-1349


### PR DESCRIPTION
*Description of changes:*
Add the CESM2 Large Ensemble (CESM2-LE) to the open data registry. This is a project which is has 500 TB of allocation on AWS to host a subset of a 100 member climate model ensemble.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.