### PR TITLE
Add U.S. 1950 census data record

### DIFF
--- a/datasets/nara-1950-census.yaml
+++ b/datasets/nara-1950-census.yaml
@@ -1,0 +1,37 @@
+Name: 1950 Census Population Schedules, Enumeration District Maps, and Enumeration District Descriptions
+
+Description: |
+  The 1950 Census population schedules were created by the Bureau of the Census in an attempt to enumerate every person living in the United States on April 1, 1950, although some persons were missed. The 1950 census population schedules were digitized by the National Archives and Records Administration (NARA) and released publicly on April 1, 2022.
+  The 1950 Census enumeration district maps contain maps of counties, cities, and other minor civil divisions that show enumeration districts, census tracts, and related boundaries and numbers used for each census. The coverage is nation wide and includes territorial areas.
+  The 1950 Census enumeration district descriptions contain written descriptions of census districts, subdivisions, and enumeration districts.
+Documentation: https://www.archives.gov/developer/1950-census
+Contact: public.dataset.program@nara.gov
+ManagedBy: National Archives and Records Administration (NARA)
+UpdateFrequency: Not updated
+Collabs:
+  ASDI:
+    Tags:
+      - socioeconomic
+Tags:
+  - nara
+  - census
+  - archives
+  - 1950 census
+  - demography
+  - aws-pds
+License: US Government work
+Resources:
+  - Description: 1950 Census
+    ARN: arn:aws:s3:::nara-1950-census
+    Region: us-east-2
+    Type: S3 Bucket    
+DataAtWork:
+  Tutorials:
+    - Title: 1950 Census on the AWS Registry of Open Data
+      URL: https://www.archives.gov/developer/1950-census
+      AuthorName: National Archives and Records Administration
+  Tools & Applications:
+    - Title: National Archives 1950 Census
+      URL: https://1950census.archives.gov
+      AuthorName: National Archives and Records Administration
+      AuthorURL: https://www.archives.gov

--- a/tags.yaml
+++ b/tags.yaml
@@ -1,4 +1,5 @@
 - 1940 census
+- 1950 census
 - acoustics
 - activity detection
 - activity recognition


### PR DESCRIPTION
Add the new 1950 census data to OpenData project that will be launched on April 1, 2022.