### PR TITLE
Add AWS blog post/tutorial that uses the Ookla data

### DIFF
--- a/datasets/speedtest-global-performance.yaml
+++ b/datasets/speedtest-global-performance.yaml
@@ -42,3 +42,6 @@ DataAtWork:
     - Title: "New Year, Great Data: The Best Ookla Open Data Projects We’ve Seen So Far"
       URL: https://www.speedtest.net/insights/blog/best-ookla-open-data-projects-2021/
       AuthorName: Katie Jolly
+    - Title: "How to deliver performant GIS desktop applications with Amazon AppStream 2.0"
+      URL: https://aws.amazon.com/blogs/publicsector/how-to-deliver-performant-gis-desktop-applications-amazon-appstream-2-0/
+      AuthorName: Ethan Fahy and Spencer DeBrosse

--- a/datasets/speedtest-global-performance.yaml
+++ b/datasets/speedtest-global-performance.yaml
@@ -47,3 +47,4 @@ DataAtWork:
       AuthorName: Ethan Fahy and Spencer DeBrosse
       Services:
         - AppStream
+        - RDS

--- a/datasets/speedtest-global-performance.yaml
+++ b/datasets/speedtest-global-performance.yaml
@@ -45,3 +45,5 @@ DataAtWork:
     - Title: "How to deliver performant GIS desktop applications with Amazon AppStream 2.0"
       URL: https://aws.amazon.com/blogs/publicsector/how-to-deliver-performant-gis-desktop-applications-amazon-appstream-2-0/
       AuthorName: Ethan Fahy and Spencer DeBrosse
+      Services:
+        - AppStream

--- a/services.yaml
+++ b/services.yaml
@@ -17,6 +17,7 @@
 - Lake Formation
 - Neptune
 - QuickSight
+- RDS
 - S3
 - SageMaker
 - SNS

--- a/services.yaml
+++ b/services.yaml
@@ -1,4 +1,5 @@
 - Athena
+- AppStream
 - AppSync
 - Batch
 - CloudFormation


### PR DESCRIPTION
Add AWS blog post/tutorial that uses the Ookla data with PostGIS on RDS and QGIS on Amazon AppStream 2.0

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
