### PR TITLE
Add entry for Defense Meterology Satellite Program auroral particle data to registry

### DIFF
--- a/datasets/dmspssj.yaml
+++ b/datasets/dmspssj.yaml
@@ -1,6 +1,6 @@
 Name: Defense Meterology Satellite Program (DMSP) Auroral Particle Flux
 Description: The United States Air Force (USAF) Defense Meteorological Satellite Program (DMSP) SSJ precipitating particle instrument measures in-situ total flux and energy distribution of electrons and ions at low earth orbit. These precipitating particles are of interest for space weather operations and research, in part because they produce aurora during normal and very strong geomagnetic storms. This dataset contains both sensor-level raw data (as detailed in Redmon et al. 2017) and a high-level machine-learning-ready data product.
-Documentation: TBD
+Documentation: https://github.com/awslabs/open-data-docs/tree/main/docs/dmspssj
 Contact: delores.knipp@colorado.edu
 ManagedBy: Space Weather Technology, Research and Education Center (TREC) at University of Colorado, Boulder
 UpdateFrequency: Infrequent

--- a/datasets/dmspssj.yaml
+++ b/datasets/dmspssj.yaml
@@ -10,7 +10,7 @@ Tags:
   - geospatial
   - earth observation
 License: This data is in the '[public domain](https://creativecommons.org/publicdomain/zero/1.0/)'
-Citation: TBD
+#Citation: TBD
 Resources: 
   - Description: DMSP Auroral Particle Flux
     ARN: arn:aws:s3:::dmspssj

--- a/datasets/dmspssj.yaml
+++ b/datasets/dmspssj.yaml
@@ -1,8 +1,8 @@
 Name: Defense Meterology Satellite Program (DMSP) Auroral Particle Flux
 Description: The United States Air Force (USAF) Defense Meteorological Satellite Program (DMSP) SSJ precipitating particle instrument measures in-situ total flux and energy distribution of electrons and ions at low earth orbit. These precipitating particles are of interest for space weather operations and research, in part because they produce aurora during normal and very strong geomagnetic storms. This dataset contains both sensor-level raw data (as detailed in Redmon et al. 2017) and a high-level machine-learning-ready data product.
 Documentation: TBD
-Contact: TBD
-ManagedBy: TBD
+Contact: delores.knipp@colorado.edu
+ManagedBy: Space Weather Technology, Research and Education Center (TREC) at University of Colorado, Boulder
 UpdateFrequency: Infrequent
 Tags:
   - solar
@@ -16,22 +16,22 @@ Resources:
     ARN: arn:aws:s3:::dmspssj
     Region: us-west-2
     Type: S3 Bucket
-    Explore: 
+#     Explore: 
 DataAtWork:
-  Tutorials:
-    - Title: 
-      URL: 
-      AuthorName: 
-      AuthorURL: 
-      Services:
+#   Tutorials:
+#     - Title: 
+#       URL: 
+#       AuthorName: 
+#       AuthorURL: 
+#       Services:
   Tools & Applications:
     - Title: ssj_latbin: Create and read ML-ready DMSP particle precipitation data
       URL: https://github.com/lkilcommons/ssj_latbin
       AuthorName: Liam Kilcommons
       AuthorURL: https://www.linkedin.com/in/liam-kilcommons-69187449/
-  Publications:
-    - Title:
-      URL:
-      AuthorName:
-      AuthorURL:
-DeprecatedNotice:
+#   Publications:
+#     - Title:
+#       URL:
+#       AuthorName:
+#       AuthorURL:
+# DeprecatedNotice:

--- a/datasets/dmspssj.yaml
+++ b/datasets/dmspssj.yaml
@@ -1,0 +1,37 @@
+Name: Defense Meterology Satellite Program (DMSP) Auroral Particle Flux
+Description: The United States Air Force (USAF) Defense Meteorological Satellite Program (DMSP) SSJ precipitating particle instrument measures in-situ total flux and energy distribution of electrons and ions at low earth orbit. These precipitating particles are of interest for space weather operations and research, in part because they produce aurora during normal and very strong geomagnetic storms. This dataset contains both sensor-level raw data (as detailed in Redmon et al. 2017) and a high-level machine-learning-ready data product.
+Documentation: TBD
+Contact: TBD
+ManagedBy: TBD
+UpdateFrequency: Infrequent
+Tags:
+  - solar
+  - space weather
+  - geospatial
+  - earth observation
+License: This data is in the '[public domain](https://creativecommons.org/publicdomain/zero/1.0/)'
+Citation: TBD
+Resources: 
+  - Description: DMSP Auroral Particle Flux
+    ARN: arn:aws:s3:::dmspssj
+    Region: us-west-2
+    Type: S3 Bucket
+    Explore: 
+DataAtWork:
+  Tutorials:
+    - Title: 
+      URL: 
+      AuthorName: 
+      AuthorURL: 
+      Services:
+  Tools & Applications:
+    - Title: ssj_latbin: Create and read ML-ready DMSP particle precipitation data
+      URL: https://github.com/lkilcommons/ssj_latbin
+      AuthorName: Liam Kilcommons
+      AuthorURL: https://www.linkedin.com/in/liam-kilcommons-69187449/
+  Publications:
+    - Title:
+      URL:
+      AuthorName:
+      AuthorURL:
+DeprecatedNotice:

--- a/tags.yaml
+++ b/tags.yaml
@@ -247,6 +247,7 @@
 - socioeconomic
 - solar
 - source code
+- space weather
 - SPARQL
 - speaker identification
 - speech processing


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Adds a first version of the .yaml file documenting the DMSP SSJ data, also adds a 'space weather' tag, since solar didn't seem quite appropriate.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
