### PR TITLE
Add ShadeMap to Tools and Applications

### DIFF
--- a/datasets/terrain-tiles.yaml
+++ b/datasets/terrain-tiles.yaml
@@ -73,6 +73,10 @@ DataAtWork:
       URL: https://clockworkmicro.com/
       AuthorName: Clockwork Micro
       AuthorURL: https://clockworkmicro.com/
+    - Title: "ShadeMap: Simulate sun shadows for any time and place on Earth"
+      URL: https://shademap.app/
+      AuthorName: Ted Piotrowski
+      AuthorURL: https://github.com/ted-piotrowski
   Publications:
     - Title: "Landscape transformations produce favorable roosting conditions for turkey vultures and black vultures"
       URL: https://www.nature.com/articles/s41598-021-94045-3


### PR DESCRIPTION
ShadeMap uses elevation data to display terrain shadows on a map in real time for any date and time

https://shademap.app