### PR TITLE
Fix wiki link, add another tutorial in Cell Painting Gallery

### DIFF
--- a/datasets/cellpainting-gallery.yaml
+++ b/datasets/cellpainting-gallery.yaml
@@ -37,7 +37,7 @@ Resources:
 DataAtWork:
   Tutorials:
     - Title: Cell Painting wiki
-      URL: broad.io/cellpaintingwiki
+      URL: https://broad.io/cellpaintingwiki
       AuthorName: Multiple Authors
       AuthorURL: https://www.broadinstitute.org/imaging
     - Title: Image-based Profiling Handbook - for processing image-based profiling datasets using CellProfiler and pycytominer
@@ -52,6 +52,10 @@ DataAtWork:
       URL: https://www.youtube.com/c/COBACenterforOpenBioimageAnalysis/videos
       AuthorName: Multiple Authors
       AuthorURL: https://openbioimageanalysis.org
+    - Title: Image-based profiling introductory exercise - data and an exercise on exploring image-based profiles, including understanding the various data levels
+      URL: https://github.com/broadinstitute/BBBC021_Morpheus_Exercise/blob/main/MorpheusExerciseWritten.pdf
+      AuthorName: Beth Cimini
+      AuthorURL: https://github.com/broadinstitute/BBBC021_Morpheus_Exercise/graphs/contributors    
   Tools & Applications:
     - Title: Pycytominer - Data processing functions for profiling perturbations
       URL: https://github.com/cytomining/pycytominer


### PR DESCRIPTION
*Description of changes:* Fixing a broken link and adding an additional tutorial for the Cell Painting Gallery resource.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
