### PR TITLE
Retire service

### DIFF
--- a/datasets/uk-met-office.yaml
+++ b/datasets/uk-met-office.yaml
@@ -1,5 +1,8 @@
-Name: UK Met Office Atmospheric Deterministic and Probabilistic Forecasts
+Name: Retired – UK Met Office Atmospheric Deterministic and Probabilistic Forecasts
 Description: |
+ 
+  As of the 13th July, no further Met Office forecasts or data will be available via this service.
+
   Meteorological data reusers now have an exciting opportunity to sample, experiment and evaluate
   Met Office atmospheric model data, whilst also experiencing a transformative method of requesting
   data via Restful APIs on AWS.


### PR DESCRIPTION
Hello, 

This service from the Met Office will be retired on the13th July 2022 and no new data will be uploaded to AWS Earth at this point.

This document should either be updated to reflect this or the entry removed from the catalogue.

Thanks,

Theo McCaie

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
