### PR TITLE
Fix broken link on AWS page

### DIFF
--- a/datasets/cmip6.yaml
+++ b/datasets/cmip6.yaml
@@ -2,7 +2,7 @@ Name: Coupled Model Intercomparison Project 6
 Description: |
   The sixth phase of global coupled ocean-atmosphere general circulation model ensemble. 
   <br /><br />
-Documentation: https://pangeo-data.github.io/pangeo-cmip6-cloud/, https://www.wcrp-climate.org/wgcm-cmip/wgcm-cmip6
+Documentation: [https://pangeo-data.github.io/pangeo-cmip6-cloud/](https://pangeo-data.github.io/pangeo-cmip6-cloud/), https://www.wcrp-climate.org/wgcm-cmip/wgcm-cmip6
 Contact: |
   If you have any feedback on the CMIP6 data available on AWS please email sustainability-data-initiative@amazon.com. We are acepting requests for additional CMIP6 variables and/or models to be made available to AWS but cannot guarantee that your request will be fulfilled. We will prioritize requests that bring value to the largest number of users. Note that we are not providing technical support through this email account.<br/><br/>
   We also seek to identify case studies on how CMIP6 data is being used and will be featuring those stories in future publications and events. If you are interested in seeing your story highlighted, please share it with the ASDI team here: sustainability-data-initiative@amazon.com.


### PR DESCRIPTION
*Issue #, if available:*

N/A

*Description of changes:*

Page https://aws.amazon.com/marketplace/pp/prodview-bx4jg33ee4j6c sends you to a 404 when you click pangeo-cmip6-cloud because the URL still contains the comma, I've moved it outside the link.

Other option is to just add a space but I think a floating comma will look kind of weird.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
