### PR TITLE
added mouselight data set

### DIFF
--- a/datasets/janelia-mouselight.yaml
+++ b/datasets/janelia-mouselight.yaml
@@ -1,0 +1,43 @@
+Name: "Mouse Brain Anatomy: MouseLight Imagery"
+Description: |
+  This data set, made available by Janelia's MouseLight project, consists of 
+  images and neuron annotations of the Mus musculus brain, stored in formats suitable
+  for viewing and annotation using the HortaCloud cloud-based annotation system.
+Documentation: https://open.quiltdata.com/b/janelia-mouselight-imagery
+Contact: hortacloud@janelia.hhmi.org
+ManagedBy: "[Janelia Research Campus](https://www.janelia.org)"
+UpdateFrequency: As required
+Tags:
+  - aws-pds
+  - biology
+  - life sciences
+  - imaging
+  - neuroscience
+  - neurobiology
+  - neuroimaging
+  - fluorescence imaging
+  - microscopy
+  - image processing
+License: "[Creative Commons Attribution 4.0 International](https://creativecommons.org/licenses/by/4.0/)"
+Resources:
+  - Description: Imagery and Metadata
+    ARN: arn:aws:s3:::janelia-mouselight-imagery
+    Region: us-east-1
+    Type: S3 Bucket
+DataAtWork:
+  Tutorials:
+  Tools & Applications:
+    - Title: MouseLight Project Website
+      URL: https://www.janelia.org/project-team/mouselight
+      AuthorName: Tiago A. Ferreira, Jayaram Chandrashekar
+    - Title: HortaCloud
+      URL: https://hortacloud.janelia.org/
+      AuthorName: David Schauder, Donald J. Olbris, Jody Clements, Cristian Goina, Robert R. Svirskas, Konrad Rokicki
+    - Title: MouseLight NeuronBrowser
+      URL: http://ml-neuronbrowser.janelia.org/
+      AuthorName: Tiago A. Ferreira, Jayaram Chandrashekar
+  Publications:
+    - Title: Reconstruction of 1,000 Projection Neurons Reveals New Cell Types and Organization of Long-Range Connectivity in the Mouse Brain
+      URL: https://doi.org/10.1016/j.cell.2019.07.042
+      AuthorName: Johan Winnubst, Erhan Bas, Tiago A. Ferreira, Zhuhao Wu, Michael N. Economo, Patrick Edson, Ben J. Arthur, Christopher Bruns, Konrad Rokicki, David Schauder, Donald J. Olbris, Sean D. Murphy, David G. Ackerman, Cameron Arshadi, Perry Baldwin, Regina Blake, Ahmad Elsayed, Mashtura Hasan, Daniel Ramirez, Bruno Dos Santos, Monet Weldon, Amina Zafar, Joshua T. Dudman, Charles R. Gerfen, Adam W. Hantman, Wyatt Korff, Scott M. Sternson, Nelson Spruston, Karel Svoboda, Jayaram Chandrashekar
+


### PR DESCRIPTION
*Issue #, if available:*
None

*Description of changes:*
Added the MouseLight data set residing in the janelia-mouselight-imagery oppen data bucket

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
