### PR TITLE
Removing the rechunked version of this dataset

### DIFF
--- a/datasets/mur.yaml
+++ b/datasets/mur.yaml
@@ -21,10 +21,6 @@ Tags:
   - weather
 License: There are no restrictions on the use of these data.
 Resources:
-  - Description: MUR Level 4 SST dataset in [Zarr](https://zarr.readthedocs.io/en/stable/) format. The zarr/ directory contains a zarr store chunked (6443, 100, 100) along the dimensions (time, lat, lon).
-    ARN: arn:aws:s3:::mur-sst/zarr
-    Region: us-west-2
-    Type: S3 Bucket
   - Description: MUR Level 4 SST dataset in [Zarr](https://zarr.readthedocs.io/en/stable/) format. The zarr-v1/ directory contains a zarr store chunked (5, 1799, 3600) along the dimensions (time, lat, lon).
     ARN: arn:aws:s3:::mur-sst/zarr-v1
     Region: us-west-2


### PR DESCRIPTION
An issue was detected with the data in this (rechunked) version of the zarr store which implicates the data is incorrect.

The tests are in this notebook: https://github.com/abarciauskas-bgse/2022-esip-kerchunk-tutorial/blob/main/MURSST-03-Tests.ipynb where the mean of the data for one day and a 5 degree x 5 degree cell is calculated for a kerchunked version of the zarr store and compared with each version of the zarr store in the AWS public datasets bucket. This calculation indicates that the data in the /zarr directory is incorrect. Upon inspection of the data, it seems like some of the data _should_ be masked as `NaN` but in the rechunked version of the data store (the data in `/zarr` with 6443 time steps per chunk) the data is not masked (i.e. there are values where we would expect `NaN`s)

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
