### PR TITLE
Reference Software Heritage S3 inventory alongside its main dataset

### DIFF
--- a/datasets/software-heritage.yaml
+++ b/datasets/software-heritage.yaml
@@ -36,6 +36,10 @@ Resources:
     ARN: arn:aws:s3:::softwareheritage
     Region: us-east-1
     Type: S3 Bucket
+  - Description: "[S3 Inventory](https://docs.aws.amazon.com/AmazonS3/latest/dev/storage-inventory.html#storage-inventory-contents) files"
+    ARN: arn:aws:s3:::softwareheritage-inventory
+    Region: us-east-1
+    Type: S3 Bucket
 DataAtWork:
   Tutorials:
   Tools & Applications:


### PR DESCRIPTION
*Description of changes:* reference the S3 inventory for the Software Heritage dataset, alongside the main dataset storage.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.