### PR TITLE
Update Maxar ODP listing

### DIFF
--- a/datasets/digital-globe-open-data.yaml
+++ b/datasets/digital-globe-open-data.yaml
@@ -22,7 +22,4 @@ Resources:
     Host: opendata.digitalglobe.com
     Region: us-east-1
     Type: CloudFront Distribution
-DataAtWork:
-  Tutorials:
-  Tools & Applications:
-  Publications:
+DeprecatedNotice: The CloudFront distribution has been retired but the original data is still available in S3. However beginning in 2022 the Open Data imagery was moved to the Maxar ARD pipeline that provides cloud-optimized imagery and metadata. See https://registry.opendata.aws/maxar-open-data/ for more information.

--- a/datasets/maxar-open-data.yaml
+++ b/datasets/maxar-open-data.yaml
@@ -4,7 +4,6 @@ Description: |
   monitoring of staging areas and emergency response, damage assessment, and recovery. These images are generated
   using the [Maxar ARD](https://ard.maxar.com/docs) pipeline, tiled on an organized grid in analysis-ready
   cloud-optimized formats.
-
 Documentation: https://www.maxar.com/open-data
 Contact: https://www.maxar.com/open-data
 UpdateFrequency: New data is released in response to activations. Older data may be migrated to the ARD format as needed.
@@ -18,9 +17,8 @@ Tags:
   - geospatial
   - satellite imagery
   - sustainability
-  - COG
-  - STAC
-  - ARCO
+  - cog
+  - stac
 License: Creative Commons Attribution Non Commercial 4.0
 ManagedBy: "[Maxar](https://www.maxar.com/)"
 Resources:
@@ -30,19 +28,33 @@ Resources:
     Host: maxar-opendata
     Region: us-east-1
     Type: S3 Bucket
+    Explore:
+    - '[STAC Catalog](https://radiantearth.github.io/stac-browser/#/external/maxar-opendata.s3.amazonaws.com/events/catalog.json)'
+    - '[STAC Browser](https://stacindex.org/catalogs/maxar-open-data-catalog-ard-format#/)'
 DataAtWork:
   Tutorials:
-    - title: ARD Deliverables and File Structure
-      url: https://ard.maxar.com/docs/ard-order-delivery/about-ard-order-delivery/
-    - title: ARD and Command Line Tools
-      url: https://ard.maxar.com/docs/working-with-ard/command-line-tools/
-    - title: Data Access (SDK tutorial)
-      url: https://ard.maxar.com/docs/sdk/sdk/data-access/
+    - Title: ARD Deliverables and File Structure
+      URL: https://ard.maxar.com/docs/ard-order-delivery/about-ard-order-delivery/
+      AuthorName: Maxar Open Data
+      AuthorURL: https://www.maxar.com/open-data
+    - Title: ARD and Command Line Tools
+      URL: https://ard.maxar.com/docs/working-with-ard/command-line-tools/
+      AuthorName: Maxar Open Data
+      AuthorURL: https://www.maxar.com/open-data
+    - Title: Data Access (SDK tutorial)
+      URL: https://ard.maxar.com/docs/sdk/sdk/data-access/
   Tools & Applications:
-    - title: Maxar ARD SDK (max-ard)
-      url: https://ard.maxar.com/docs/sdk/
-    - title: STAC Catalog (via STAC Index)
-      url: https://stacindex.org/catalogs/maxar-open-data-catalog-ard-format#/
-    - title: STAC Catalog (via STAC Browser)
-      url: https://radiantearth.github.io/stac-browser/#/external/maxar-opendata.s3.amazonaws.com/events/catalog.json
+    - Title: Maxar ARD SDK (max-ard)
+      URL: https://ard.maxar.com/docs/sdk/
+      AuthorName: Maxar Open Data
+      AuthorURL: https://www.maxar.com/open-data
   Publications:
+    - Title: Seeing a Better World from Space
+      URL: https://docs.lib.purdue.edu/cgi/viewcontent.cgi?article=1124&context=purduegisday
+      AuthorName: Carly Sakumura
+    - Title: Using Data from Earth Observation to Support Sustainable Development Indicators: An Analysis of the Literature and Challenges for the Future 
+      URL: https://doi.org/10.3390/su14031191
+      AuthorName: Ana Andries, Stephen Morse, Richard J. Murphy, Jim Lynch, and Emma R. Woolliams
+    - Title: Disaster, Infrastructure and Participatory Knowledge The Planetary Response Network
+      URL: https://eprints.lancs.ac.uk/id/eprint/167032/1/Simmons_et_al_2022_CSTP_PRN_Paper_Special_Issue_Accepted_Version.pdf
+      AuthorName: Brooke Simmons, Chris Lintott, Steven Reece, et al.

--- a/datasets/maxar-open-data.yaml
+++ b/datasets/maxar-open-data.yaml
@@ -1,0 +1,48 @@
+Name: Maxar Open Data Program
+Description: |
+  Pre and post event high-resolution satellite imagery in support of emergency planning, risk assessment, 
+  monitoring of staging areas and emergency response, damage assessment, and recovery. These images are generated
+  using the [Maxar ARD](https://ard.maxar.com/docs) pipeline, tiled on an organized grid in analysis-ready
+  cloud-optimized formats.
+
+Documentation: https://www.maxar.com/open-data
+Contact: https://www.maxar.com/open-data
+UpdateFrequency: New data is released in response to activations. Older data may be migrated to the ARD format as needed.
+Collabs:
+  ASDI:
+    Tags:
+      - disaster response
+Tags:
+  - earth observation
+  - disaster response
+  - geospatial
+  - satellite imagery
+  - sustainability
+  - COG
+  - STAC
+  - ARCO
+License: Creative Commons Attribution Non Commercial 4.0
+ManagedBy: "[Maxar](https://www.maxar.com/)"
+Resources:
+  - Description: Imagery and metadata
+    ARN: arn:aws:s3:::maxar-opendata
+    AccountRequired: no
+    Host: maxar-opendata
+    Region: us-east-1
+    Type: S3 Bucket
+DataAtWork:
+  Tutorials:
+    - title: ARD Deliverables and File Structure
+      url: https://ard.maxar.com/docs/ard-order-delivery/about-ard-order-delivery/
+    - title: ARD and Command Line Tools
+      url: https://ard.maxar.com/docs/working-with-ard/command-line-tools/
+    - title: Data Access (SDK tutorial)
+      url: https://ard.maxar.com/docs/sdk/sdk/data-access/
+  Tools & Applications:
+    - title: Maxar ARD SDK (max-ard)
+      url: https://ard.maxar.com/docs/sdk/
+    - title: STAC Catalog (via STAC Index)
+      url: https://stacindex.org/catalogs/maxar-open-data-catalog-ard-format#/
+    - title: STAC Catalog (via STAC Browser)
+      url: https://radiantearth.github.io/stac-browser/#/external/maxar-opendata.s3.amazonaws.com/events/catalog.json
+  Publications:

--- a/datasets/maxar-open-data.yaml
+++ b/datasets/maxar-open-data.yaml
@@ -24,10 +24,9 @@ ManagedBy: "[Maxar](https://www.maxar.com/)"
 Resources:
   - Description: Imagery and metadata
     ARN: arn:aws:s3:::maxar-opendata
-    AccountRequired: no
-    Host: maxar-opendata
     Region: us-east-1
     Type: S3 Bucket
+    AccountRequired: no
     Explore:
     - '[STAC Catalog](https://radiantearth.github.io/stac-browser/#/external/maxar-opendata.s3.amazonaws.com/events/catalog.json)'
     - '[STAC Browser](https://stacindex.org/catalogs/maxar-open-data-catalog-ard-format#/)'
@@ -41,7 +40,7 @@ DataAtWork:
       URL: https://ard.maxar.com/docs/working-with-ard/command-line-tools/
       AuthorName: Maxar Open Data
       AuthorURL: https://www.maxar.com/open-data
-    - Title: Data Access (SDK tutorial)
+    - Title: "Data Access (SDK tutorial)"
       URL: https://ard.maxar.com/docs/sdk/sdk/data-access/
   Tools & Applications:
     - Title: Maxar ARD SDK (max-ard)

--- a/datasets/maxar-open-data.yaml
+++ b/datasets/maxar-open-data.yaml
@@ -42,6 +42,8 @@ DataAtWork:
       AuthorURL: https://www.maxar.com/open-data
     - Title: "Data Access (SDK tutorial)"
       URL: https://ard.maxar.com/docs/sdk/sdk/data-access/
+      AuthorName: Maxar Open Data
+      AuthorURL: https://www.maxar.com/open-data
   Tools & Applications:
     - Title: Maxar ARD SDK (max-ard)
       URL: https://ard.maxar.com/docs/sdk/

--- a/datasets/maxar-open-data.yaml
+++ b/datasets/maxar-open-data.yaml
@@ -52,9 +52,9 @@ DataAtWork:
     - Title: Seeing a Better World from Space
       URL: https://docs.lib.purdue.edu/cgi/viewcontent.cgi?article=1124&context=purduegisday
       AuthorName: Carly Sakumura
-    - Title: Using Data from Earth Observation to Support Sustainable Development Indicators: An Analysis of the Literature and Challenges for the Future 
+    - Title: "Using Data from Earth Observation to Support Sustainable Development Indicators: An Analysis of the Literature and Challenges for the Future"
       URL: https://doi.org/10.3390/su14031191
       AuthorName: Ana Andries, Stephen Morse, Richard J. Murphy, Jim Lynch, and Emma R. Woolliams
-    - Title: Disaster, Infrastructure and Participatory Knowledge The Planetary Response Network
+    - Title: "Disaster, Infrastructure and Participatory Knowledge The Planetary Response Network"
       URL: https://eprints.lancs.ac.uk/id/eprint/167032/1/Simmons_et_al_2022_CSTP_PRN_Paper_Special_Issue_Accepted_Version.pdf
       AuthorName: Brooke Simmons, Chris Lintott, Steven Reece, et al.


### PR DESCRIPTION
Maxar's Open Data imagery was recently updated to use a new source pipeline that outputs the images and metadata in cloud-native formats . A new bucket location is being used to store these images. Additionally we have resources and tutorials to help users take advantage of the updated imagery.

The original listing has now been marked as deprecated as the `digitalglobe` domain is largely defunct and the listed CloudFront distribution no longer exists. The images still are stored in an S3 bucket and access is available upon request. Some of the images may be migrated to the new format and location if needed.

