### PR TITLE
CBERS 4 update; CBERS-4A AWFI scenes being ingested

### DIFF
--- a/datasets/cbers.yaml
+++ b/datasets/cbers.yaml
@@ -10,8 +10,11 @@ Description: |
   PAN10M scenes acquired since
   the start of the satellite mission and is daily updated with
   new scenes.
+  CBERS-4 PAN5M and PAN10M starting from 05-2022 are temporarily not ingested
+  due to an error in the bands identification on INPE's catalog.
   CBERS-4A MUX Level 4 (Orthorectified) scenes are being
-  ingested starting from 04-13-2021.
+  ingested starting from 04-13-2021. CBERS-4A WFI Level 4 (Orthorectified)
+  scenes are being ingested starting from 10-12-2022.
 Documentation: https://github.com/fredliporace/cbers-on-aws
 Contact: https://lists.osgeo.org/mailman/listinfo/cbers-pds
 ManagedBy: "[AMS Kepler](https://amskepler.com/)"
@@ -44,24 +47,12 @@ Resources:
     ARN: arn:aws:s3:::cbers-meta-pds
     Region: us-east-1
     Type: S3 Bucket
-  - Description: Notifications for new MUX quicklooks
-    ARN: arn:aws:sns:us-east-1:599544552497:NewCB4MUXQuicklook
-    Region: us-east-1
-    Type: SNS Topic
-  - Description: Notifications for new AWFI quicklooks
-    ARN: arn:aws:sns:us-east-1:599544552497:NewCB4AWFIQuicklook
-    Region: us-east-1
-    Type: SNS Topic
-  - Description: Notifications for new PAN10M quicklooks
-    ARN: arn:aws:sns:us-east-1:599544552497:NewCB4PAN10MQuicklook
-    Region: us-east-1
-    Type: SNS Topic
-  - Description: Notifications for new PAN5M quicklooks
-    ARN: arn:aws:sns:us-east-1:599544552497:NewCB4PAN5MQuicklook
-    Region: us-east-1
-    Type: SNS Topic
   - Description: Notifications for new CBERS 4A quicklooks, all sensors
     ARN: arn:aws:sns:us-east-1:599544552497:NewCB4AQuicklook
+    Region: us-east-1
+    Type: SNS Topic
+  - Description: Notifications for new CBERS 4 quicklooks, all sensors
+    ARN: arn:aws:sns:us-east-1:599544552497:NewCB4Quicklook
     Region: us-east-1
     Type: SNS Topic
   - Description: Topic that receives STAC V1.0.0 items as new scenes are ingested


### PR DESCRIPTION
*Issue #:*  NA

*Description of changes:*

Changes related to the use of a [new catalog for CBERS-4 scenes](http://www.dgi.inpe.br/) starting 05-10-2022.

* New SNS topic for CBERS4 scenes; the old topics are not used anymore.
* CBERS4 PAN5M and PAN10M ingestion temporarily suspended.
* CBERS4A/WFI scenes started being ingested.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
