### PR TITLE
fixed broken link for PersonPath22 dataset

### DIFF
--- a/datasets/person-path-22.yaml
+++ b/datasets/person-path-22.yaml
@@ -1,6 +1,6 @@
 Name: PersonPath22
 Description: PersonPath22 is a large-scale multi-person tracking dataset containing 236 videos captured mostly from static-mounted cameras,  collected from sources where we were given the rights to redistribute the content and participants have given explicit consent. Each video has ground-truth annotations including both bounding boxes and tracklet-ids for all the persons in each frame.
-Documentation: https://amazon-research.github.io/tracking-dataset/personpath22.html
+Documentation: https://amazon-science.github.io/tracking-dataset/personpath22.html
 Contact: Post any questions to [re:Post](https://repost.aws/tags/questions/TApd0Wl5P8S9O6riTWmh-cGw/aws-open-data) and use the `AWS Open Data` tag.
 ManagedBy: "[Amazon Web Services](https://aws.amazon.com/)"
 UpdateFrequency: Periodically


### PR DESCRIPTION
Due to the org-wide domain renaming for GitHub (from "amazon-research" to "amazon-science"), the provided link in the dataset page (https://registry.opendata.aws/person-path-22/) is broken and has to be updated
