### PR TITLE
add topo map SVG tool to mapzen dataset

### DIFF
--- a/datasets/terrain-tiles.yaml
+++ b/datasets/terrain-tiles.yaml
@@ -82,6 +82,10 @@ DataAtWork:
       URL: https://shademap.app/
       AuthorName: Ted Piotrowski
       AuthorURL: https://github.com/ted-piotrowski
+    - Title: "Download topographical map contour lines as SVGs"
+      URL: https://buntinglabs.com/tools/download-topo-map-contour-lines
+      AuthorName: Bunting Labs
+      AuthorURL: https://buntinglabs.com/
   Publications:
     - Title: "Landscape transformations produce favorable roosting conditions for turkey vultures and black vultures"
       URL: https://www.nature.com/articles/s41598-021-94045-3


### PR DESCRIPTION
*Issue #, if available:*
- N/A

*Description of changes:*
- add tool that lets you download an SVG of a topographical map from this dataset

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
