### PR TITLE
Improve Sentinel-2 data product description

### DIFF
--- a/datasets/sentinel-2.yaml
+++ b/datasets/sentinel-2.yaml
@@ -49,12 +49,12 @@ Resources:
     ARN: arn:aws:s3:::sentinel-inventory/sentinel-s2-l2a
     Region: eu-central-1
     Type: S3 Bucket
-  - Description: Zipped archives for each product with 3 day retention period, in Requester Pays bucket
+  - Description: Zipped archives for each L1C product with 3 day retention period, in Requester Pays bucket
     ARN: arn:aws:s3:::sentinel-s2-l1c-zips
     Region: eu-central-1
     Type: S3 Bucket
     RequesterPays: True
-  - Description: Zipped archives for each product with 3 day retention period, in Requester Pays bucket
+  - Description: Zipped archives for each L2A product with 3 day retention period, in Requester Pays bucket
     ARN: arn:aws:s3:::sentinel-s2-l2a-zips
     Region: eu-central-1
     Type: S3 Bucket


### PR DESCRIPTION
*Description of changes:*

Adds `L1C` and `L2A` to the data product description to avoid both product descriptions being the same. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
