### PR TITLE
Added 2022 and 2023 S3 buckets for pacific-sound

### DIFF
--- a/datasets/pacific-sound.yaml
+++ b/datasets/pacific-sound.yaml
@@ -54,6 +54,14 @@ Resources:
     ARN: arn:aws:s3:::pacific-sound-256khz-2021
     Region: us-west-2
     Type: S3 Bucket
+  - Description: original 256 kHz audio recordings year 2022
+    ARN: arn:aws:s3:::pacific-sound-256khz-2022
+    Region: us-west-2
+    Type: S3 Bucket
+  - Description: original 256 kHz audio recordings year 2023
+    ARN: arn:aws:s3:::pacific-sound-256khz-2023
+    Region: us-west-2
+    Type: S3 Bucket
   - Description: decimated 2 kHz audio recordings
     ARN: arn:aws:s3:::pacific-sound-2khz
     Region: us-west-2


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

This is a simple request to add the public 2022 and 2023 S3 buckets to the AWS registry for the Pacific Sound Archive.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
