### PR TITLE
✨ Updating Kids First Registry for 2023

### DIFF
--- a/datasets/kids-first.yaml
+++ b/datasets/kids-first.yaml
@@ -78,11 +78,6 @@ Resources:
     Region: us-east-1
     Type: S3 Bucket
     ControlledAccess: https://www.ncbi.nlm.nih.gov/projects/gap/cgi-bin/study.cgi?study_id=phs001420.v1.p1
-  - Description: "Kids First: Genomics of Orofacial Cleft Birth Defects in Latin American Families"
-    ARN: arn:aws:s3:::kf-study-us-east-1-prd-sd-r0eprsgs
-    Region: us-east-1
-    Type: S3 Bucket
-    ControlledAccess: https://www.ncbi.nlm.nih.gov/projects/gap/cgi-bin/study.cgi?study_id=phs001420.v1.p1
   - Description: "Discovering the Genetic Basis of Human Neuroblastoma: A Gabriella Miller Kids First Pediatric Research Program (Kids First) Project"
     ARN: arn:aws:s3:::kf-study-us-east-1-prd-sd-dypmehhf
     Region: us-east-1
@@ -103,6 +98,104 @@ Resources:
     Region: us-east-1
     Type: S3 Bucket
     ControlledAccess: https://www.ncbi.nlm.nih.gov/projects/gap/cgi-bin/study.cgi?study_id=phs001997.v1.p1
+  - Description: "Kids First: Whole Genome Sequencing of Nonsyndromic Craniosynostosis"
+    ARN: arn:aws:s3:::kf-study-us-east-1-prd-sd-p445achv
+    Region: us-east-1
+    Type: S3 Bucket
+    ControlledAccess: https://www.ncbi.nlm.nih.gov/projects/gap/cgi-bin/study.cgi?study_id=phs001806.v1.p1
+  - Description: "Gabriella Miller Kids First Pediatric Research Program in Germline and Somatic Variants in Myeloid Malignancies in Children"
+    ARN: arn:aws:s3:::kf-study-us-east-1-prd-sd-pet7q6f2
+    Region: us-east-1
+    Type: S3 Bucket
+    ControlledAccess: https://www.ncbi.nlm.nih.gov/projects/gap/cgi-bin/study.cgi?study_id=phs002187.v1.p1
+  - Description: "Kids First and INCLUDE: Down Syndrome, Heart Defects, and Acute Lymphoblastic Leukemia"
+    ARN: arn:aws:s3:::kf-study-us-east-1-prd-sd-z6mwd3h0
+    Region: us-east-1
+    Type: S3 Bucket
+    ControlledAccess: https://www.ncbi.nlm.nih.gov/projects/gap/cgi-bin/study.cgi?study_id=phs002330.v1.p1
+  - Description: "Kids First: Genetics of Kidney and Urinary Tract Malformations"
+    ARN: arn:aws:s3:::kf-study-us-east-1-prd-sd-nmvv8a1y
+    Region: us-east-1
+    Type: S3 Bucket
+    ControlledAccess: https://www.ncbi.nlm.nih.gov/projects/gap/cgi-bin/study.cgi?study_id=phs002162.v2.p1
+  - Description: "Gabriella Miller Kids First Pediatric Research Program in Genetics at the Intersection of Childhood Cancer and Birth Defects"
+    ARN: arn:aws:s3:::kf-study-us-east-1-prd-sd-jws3v24d
+    Region: us-east-1
+    Type: S3 Bucket
+    ControlledAccess: https://www.ncbi.nlm.nih.gov/projects/gap/cgi-bin/study.cgi?study_id=phs001846.v1.p1
+  - Description: "Pediatric Brain Tumor Atlas: PNOC"
+    ARN: arn:aws:s3:::kf-study-us-east-1-prd-sd-m3dbxd12
+    Region: us-east-1
+    Type: S3 Bucket
+    ControlledAccess: https://www.ncbi.nlm.nih.gov/projects/gap/cgi-bin/study.cgi?study_id=phs002517.v1.p1
+  - Description: "Kids First Pediatric Research Study in Familial Predisposition to Hematopoietic Malignancies (SJFAMILY-HM)"
+    ARN: arn:aws:s3:::kf-study-us-east-1-prd-sd-w0v965xz
+    Region: us-east-1
+    Type: S3 Bucket
+    ControlledAccess: https://www.ncbi.nlm.nih.gov/projects/gap/cgi-bin/study.cgi?study_id=phs001738.v1.p1
+  - Description: "Gabriella Miller Kids First Pediatric Research Program: An Integrated Clinical and Genomic Analysis of Treatment Failure in Pediatric Osteosarcoma"
+    ARN: arn:aws:s3:::kf-study-us-east-1-prd-sd-zxjffmef
+    Region: us-east-1
+    Type: S3 Bucket
+    ControlledAccess: https://www.ncbi.nlm.nih.gov/projects/gap/cgi-bin/study.cgi?study_id=phs001714.v1.p1 
+  - Description: "Chordoma Foundation Dataset"
+    ARN: arn:aws:s3:::kf-study-us-east-1-prd-sd-7spqtt8m
+    Region: us-east-1
+    Type: S3 Bucket
+    ControlledAccess: https://cavatica.sbgenomics.com/p/datasets#cavatica/cbttc-cdhm-pa-01
+  - Description: "Clinical Sequencing Exploratory Research Consortium: Incorporation of Genomic Sequencing into Pediatric Cancer Care"
+    ARN: arn:aws:s3:::kf-study-us-east-1-prd-sd-zfgdg5ys
+    Region: us-east-1
+    Type: S3 Bucket
+    ControlledAccess: https://www.ncbi.nlm.nih.gov/projects/gap/cgi-bin/study.cgi?study_id=phs001683.v2.p1
+  - Description: "Kids First: Genomic Analysis of Esophageal Atresia and Tracheoesophageal Fistulas and Associated Congenital Anomalies"
+    ARN: arn:aws:s3:::kf-study-us-east-1-prd-sd-0tyvy1tw
+    Region: us-east-1
+    Type: S3 Bucket
+    ControlledAccess: https://www.ncbi.nlm.nih.gov/projects/gap/cgi-bin/study.cgi?study_id=phs002161.v1.p1
+  - Description: "Gabriella Miller Kids First Pediatric Research Program in Bladder Exstrophy, Epispadias, Complex (BEEC)"
+    ARN: arn:aws:s3:::kf-study-us-east-1-prd-sd-z0d9n23x
+    Region: us-east-1
+    Type: S3 Bucket
+    ControlledAccess: https://www.ncbi.nlm.nih.gov/projects/gap/cgi-bin/study.cgi?study_id=phs002173.v1.p1
+  - Description: "Children's Brain Tumor Network"
+    ARN: arn:aws:s3:::kf-study-us-east-1-prd-sd-bhjxbdqk
+    Region: us-east-1
+    Type: S3 Bucket
+    ControlledAccess: https://www.ncbi.nlm.nih.gov/projects/gap/cgi-bin/study.cgi?study_id=phs002517.v1.p1
+  - Description: "Kids First: Structural Defects of The Neural Tube"
+    ARN: arn:aws:s3:::kf-study-us-east-1-prd-sd-15a2mqq9
+    Region: us-east-1
+    Type: S3 Bucket
+    ControlledAccess: https://www.ncbi.nlm.nih.gov/projects/gap/cgi-bin/study.cgi?study_id=phs002591.v1.p1
+  - Description: "Gabriella Miller Kids First Pediatric Research Project in Cornelia de Lange Syndrome, Related Diagnosis and Structural Birth Defects"
+    ARN: arn:aws:s3:::kf-study-us-east-1-prd-sd-2cekq05v
+    Region: us-east-1
+    Type: S3 Bucket
+    ControlledAccess: https://www.ncbi.nlm.nih.gov/projects/gap/cgi-bin/study.cgi?study_id=phs002174.v1.p1
+  - Description: "Gabriella Miller Kids First Pediatric Research Program in Pediatric T-cell Acute Lymphoblastic Leukemia"
+    ARN: arn:aws:s3:::kf-study-us-east-1-prd-sd-aq9kvn5p
+    Region: us-east-1
+    Type: S3 Bucket
+    ControlledAccess: https://www.ncbi.nlm.nih.gov/projects/gap/cgi-bin/study.cgi?study_id=phs002276.v2.p1
+  - Description: "Gabriella Miller Kids First Pediatric Research Program in Craniofacial Microsomia"
+    ARN: arn:aws:s3:::kf-study-us-east-1-prd-sd-b8x3c1mx
+    Region: us-east-1
+    Type: S3 Bucket
+    ControlledAccess: https://www.ncbi.nlm.nih.gov/projects/gap/cgi-bin/study.cgi?study_id=phs002130.v1.p1
+  - Description: "Gabriella Miller Kids First Pediatric Research Project in Microtia in Hispanic Populations"
+    ARN: arn:aws:s3:::kf-study-us-east-1-prd-sd-dz4gpqx6
+    Region: us-east-1
+    Type: S3 Bucket
+    ControlledAccess: https://www.ncbi.nlm.nih.gov/projects/gap/cgi-bin/study.cgi?study_id=phs002172.v1.p1
+  - Description: "The Collaboration to Assess Risk and Identify LoNG-term outcomes for Children with COVID (CARING for Children with COVID) - NICHD-2019-POP02: Pharmacokinetics, Pharmacodynamics, and Safety Profile of Understudied Drugs Administered to Children per Standard of Care"
+    ARN: arn:aws:s3:::kf-study-us-east-1-prd-sd-ffvq3t38
+    Region: us-east-1
+    Type: S3 Bucket
+    ControlledAccess: https://www.ncbi.nlm.nih.gov/projects/gap/cgi-bin/study.cgi?study_id=phs002577.v1.p1
+
+
+
 DataAtWork:
   Tools & Applications:
     - Title: Kids First DRC Portal


### PR DESCRIPTION
Now contains pediatric genomic data for 31 studies.

*Issue #, if available:*

*Description of changes:*
Also removed one duplicate entry.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
