### PR TITLE
Update metadata about IndiogAg's Sentinel-1 RTC dataset

### DIFF
--- a/datasets/sentinel-1-rtc-indigo.yaml
+++ b/datasets/sentinel-1-rtc-indigo.yaml
@@ -27,6 +27,8 @@ Tags:
   - stac
   - synthetic aperture radar
 License: |
+  The use of these data fall under the terms and conditions of the [Indigo Atlas Sentinel License](https://www.indigoag.com/forms/atlas-sentinel-license) included below. Contains modified Copernicus Sentinel data.
+
   Indigo Ag, Inc. and our affiliates (“Indigo”) provide access to the Indigo Atlas Analysis-Ready Sentinel-1 Backscatter Imagery dataset (“Atlas-Sentinel”) to you subject to the following terms and conditions. If you do not agree to be bound by the terms of the Agreement do not use, download, or otherwise access Atlas-Sentinel.
 
   Subject to the terms of the Agreement, Indigo grants you a non-exclusive, non-assignable, non-sublicensable, non-transferable, revocable, limited license to access and use Atlas-Sentinel for the purpose of academic or non-profit research. You may not use Atlas-Sentinel for commercial research including without limitation research through a funding agreement, consultancy, internship, or other relationship in which your results are delivered to a for-profit organization, regardless of whether you are compensated for such research. Contact our business development team (AtlasSupport@indigoag.com) to learn more about commercial partnerships.

--- a/datasets/sentinel-1-rtc-indigo.yaml
+++ b/datasets/sentinel-1-rtc-indigo.yaml
@@ -27,8 +27,19 @@ Tags:
   - stac
   - synthetic aperture radar
 License: |
-  The use of these data fall under the terms and conditions of the [Indigo Atlas Sentinel License](https://www.indigoag.com/forms/atlas-sentinel-license).
-  Contains modified Copernicus Sentinel data.
+  Indigo Ag, Inc. and our affiliates (“Indigo”) provide access to the Indigo Atlas Analysis-Ready Sentinel-1 Backscatter Imagery dataset (“Atlas-Sentinel”) to you subject to the following terms and conditions. If you do not agree to be bound by the terms of the Agreement do not use, download, or otherwise access Atlas-Sentinel.
+
+  Subject to the terms of the Agreement, Indigo grants you a non-exclusive, non-assignable, non-sublicensable, non-transferable, revocable, limited license to access and use Atlas-Sentinel for the purpose of academic or non-profit research. You may not use Atlas-Sentinel for commercial research including without limitation research through a funding agreement, consultancy, internship, or other relationship in which your results are delivered to a for-profit organization, regardless of whether you are compensated for such research. Contact our business development team (AtlasSupport@indigoag.com) to learn more about commercial partnerships.
+
+  Please include an attribution similar to the following “Created using Indigo Atlas Analysis-Ready Sentinel-1 Backscatter Imagery https://www.indigoag.com, [YEAR]” with any graphics or reports generated using Atlas-Sentinel.
+
+  NEITHER INDIGO NOR ANY OF OUR RESPECTIVE OFFICERS, DIRECTORS, MEMBERS, EMPLOYEES, AGENTS, CONSULTANTS OR LICENSORS (each a “RELATED PARTY”) MAKE ANY REPRESENTATIONS OR WARRANTIES WITH RESPECT TO ATLAS-SENTINEL AND EACH HEREBY DISCLAIMS AND SHALL HAVE NO LIABILITY FOR ALL REPRESENTATIONS AND WARRANTIES, EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION TO THE MERCHANTABILITY, QUALITY OF ATLAS-SENTINEL OR FITNESS FOR A PARTICULAR PURPOSE, UNINTERRUPTED SERVICE OR ERROR-FREE SERVICE, OR THE SEQUENCE, TIMELINESS, ACCURACY OR COMPLETENESS OF ATLAS-SENTINEL. ATLAS-SENTINEL IS PROVIDED ON AN “AS IS” BASIS AT YOUR SOLE RISK. YOU ACKNOWLEDGE THAT:(I) YOU MAY EXPERIENCE INTERRUPTIONS OR ERRORS IN THE ATLAS-SENTINEL; AND (II) ATLAS-SENTINEL MAY, FROM TIME TO TIME, BE TEMPORARILY UNAVAILABLE.
+
+  TO THE MAXIMUM EXTENT PERMITTED BY LAW, IN NO CIRCUMSTANCES SHALL INDIGO OR ANY RELATED PARTIES BE LIABLE HEREUNDER TO YOU OR TO OTHERS DIRECTLY OR INDIRECTLY MAKING USE OF THE ATLAS-SENTINEL, FOR ANY LOST PROFITS, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY OR CONSEQUENTIAL DAMAGES, ARISING UNDER THESE TERMS OF USE, EVEN IF INDIGO HAS BEEN ADVISED OF THE POSSIBILITY THEREOF AND EVEN IF DUE TO INDIGO’S ERROR, OMISSION, OR NEGLIGENCE.
+
+  TO THE MAXIMUM EXTENT ALLOWABLE BY LAW, IN NO CIRCUMSTANCES SHALL INDIGO OR ANY RELATED PARTIES BE LIABLE FOR ANY (A) DELAY, INACCURACIES, ERRORS, OMISSIONS OR INTERRUPTION OF ANY KIND IN RELATION TO ATLAS-SENTINEL OR FOR ANY RESULTING LOSS OR DAMAGE; OR (B) LOSS OR DAMAGE ARISING FROM UNAUTHORIZED ACCESS TO OR MISUSE OF ATLAS-SENTINEL. TO THE MAXIMUM EXTENT PERMITTED BY LAW, IN NO EVENT SHALL THE AGGREGATE LIABILITY OF INDIGO OR ANY RELATED PARTIES HEREUNDER EXCEED THE LESSER OF:(A) THE FEES PAID TO INDIGO BY YOU HEREUNDER IN THE TWELVE (12) MONTHS IMMEDIATELY PRECEDING THE EVENT GIVING RISE TO THE CLAIM; OR (B) FIFTY US DOLLARS ($50), REGARDLESS OF WHETHER SUCH DAMAGES ARE BASED IN CONTRACT, TORT, STRICT LIABILITY, OR OTHERWISE. THIS LIMITATION SHALL SURVIVE FAILURE OF ESSENTIAL PURPOSE OF ANY REMEDIES THAT MAY BE PROVIDED IN THIS AGREEMENT.
+
+  Accessing or using Atlas-Sentinel in violation of this Agreement immediately terminates your license to Atlas-Sentinel without limiting any other remedies Indigo may have.
 Resources:
   - Description: Sentinel-1 RTC tiled data and metadata in a S3 bucket
     ARN: arn:aws:s3:::sentinel-s1-rtc-indigo

--- a/datasets/sentinel-1-rtc-indigo.yaml
+++ b/datasets/sentinel-1-rtc-indigo.yaml
@@ -10,7 +10,7 @@ Description: |
 Documentation: https://sentinel-s1-rtc-indigo-docs.s3-us-west-2.amazonaws.com/index.html
 Contact: For questions regarding data methodology or delivery, contact sentinel1@indigoag.com.
 ManagedBy: "[Indigo Ag, Inc.](https://www.indigoag.com/)"
-UpdateFrequency: Data are updated on a daily cadence for the dataset's spatial domain (CONUS).
+UpdateFrequency: Data updates are paused while we repair the processing pipeline, but the target is to update on a daily cadence for the dataset's spatial domain (CONUS).
 Collabs:
   ASDI:
     Tags:


### PR DESCRIPTION
This PR seeks to address two issues with the metadata about our dataset hosted on AWS RODA,

1. Our license page had become inaccessible. We restored this page so the existing link works, but have also embedded the license text in case that happens again.
2. We had an interruption [related to changes in how we can source orbit metadata](https://forum.step.esa.int/t/orbit-file-timeout-march-2021/28621/217) that brought down our pipeline. We have been able to fix it, but need to push this to our "production" and backfill. I added a brief note reflecting this current status

cc @jeffejefe 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
