### PR TITLE
Add NCI Imaging Data Commons dataset

### DIFF
--- a/datasets/nci-imaging-data-commons.yaml
+++ b/datasets/nci-imaging-data-commons.yaml
@@ -1,0 +1,55 @@
+Name: National Cancer Institute Imaging Data Commons (IDC) Collections
+Description: |
+  [Imaging Data Commons (IDC)](https://imaging.datacommons.cancer.gov)  is a repository within the 
+  [Cancer Research Data Commons (CRDC)](https://datacommons.cancer.gov) that manages imaging data 
+  and enables its integration with the other components of CRDC. 
+
+  IDC hosts a growing number of imaging collections that are contributed 
+  by either funded US National Cancer Institute (NCI)  data collection 
+  activities, or by the individual researchers.
+
+  Image data hosted by IDC is stored in DICOM  format. 
+Documentation: https://learn.canceridc.dev/
+Contact: https://discourse.canceridc.dev/
+ManagedBy: "Imaging Data Commons (IDC)(https://imaging.datacommons.cancer.gov) team"
+UpdateFrequency: Every 1-3 months
+Tags:
+  - aws-pds
+  - cancer
+  - imaging
+  - digital pathology
+  - radiology
+  - microscopy
+  - fluorescence imaging
+  - image processing
+  - machine learning
+License: https://fairsharing.org/FAIRsharing.0b5a1d
+Resources:
+  - Description: De-identified imaging data files in DICOM format distributed under CC-BY license. This bucket is updated with each new IDC release, while maintaining the versioning of the previous releases, as described in the [IDC Data versioning](https://learn.canceridc.dev/docs/data-versioning) documentation. The content of the buckets is [organized](https://learn.canceridc.dev/data/organization-of-data/files-and-metadata) into folders corresponding to versioned DICOM series, with different versions of the series located in the same bucket. Please refer to the [IDC Documentation](https://learn.canceridc.dev/) and [tutorials](https://github.com/ImagingDataCommons/IDC-Tutorials/tree/master/notebooks/getting_started) to learn how to search and download the data, and how to comply with attribution requirements.
+    ARN: arn:aws:s3:::idc-open-data
+    Region: us-east-1
+    Type: S3 Bucket
+  - Description: Second bucket containing de-identified imaging data files in DICOM format distributed under CC-BY license. This bucket is updated with each new IDC release, while maintaining the versioning of the previous releases, as described in the [IDC Data versioning](https://learn.canceridc.dev/docs/data-versioning) documentation. The content of the buckets is [organized](https://learn.canceridc.dev/data/organization-of-data/files-and-metadata) into folders corresponding to versioned DICOM series, with different versions of the series located in the same bucket. Please refer to the [IDC Documentation](https://learn.canceridc.dev/) and [tutorials](https://github.com/ImagingDataCommons/IDC-Tutorials/tree/master/notebooks/getting_started) to learn how to search and download the data, and how to comply with attribution requirements.
+    ARN: arn:aws:s3:::idc-open-datap-two
+    Region: us-east-1
+    Type: S3 Bucket
+  - Description: De-identified imaging data files in DICOM format distributed under CC-NC license. Files in this bucket are covered by This bucket is updated with each new IDC release, while maintaining the versioning of the previous releases, as described in the [IDC Data versioning](https://learn.canceridc.dev/docs/data-versioning) documentation. The content of the buckets is [organized](https://learn.canceridc.dev/data/organization-of-data/files-and-metadata) into folders corresponding to versioned DICOM series, with different versions of the series located in the same bucket. Please refer to the [IDC Documentation](https://learn.canceridc.dev/) and [tutorials](https://github.com/ImagingDataCommons/IDC-Tutorials/tree/master/notebooks/getting_started) to learn how to search and download the data, and how to comply with attribution requirements.
+    ARN: arn:aws:s3:::idc-open-data-cr
+    Region: us-east-1
+    Type: S3 Bucket
+DataAtWork:
+  Tools & Applications:
+    - Title: IDC Portal
+      URL: https://portal.imaging.datacommons.cancer.gov/
+      AuthorName: Imaging Data Commons team
+      AuthorURL: https://learn.canceridc.dev/idc-team
+  Tutorials:
+    - Title: IDC "Getting started" tutorial series
+      URL: https://github.com/ImagingDataCommons/IDC-Tutorials/tree/master/notebooks/getting_started
+      AuthorName: Imaging Data Commons team
+      AuthorURL: https://learn.canceridc.dev/idc-team
+  Publications:
+    - Title: NCI Imaging Data Commons
+      URL: https://doi.org/10.1158/0008-5472.can-21-0950
+      AuthorName: Fedorov A, Longabaugh W, Pot D, Clunie D, Pieper S, Aerts H, et al.
+      AuthorURL: https://learn.canceridc.dev/idc-team


### PR DESCRIPTION
This is initial draft introducing [NCI Imaging Data Commons](https://portal.imaging.datacommons.cancer.gov/) dataset, in preparation to the public release.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
