### PR TITLE
NASA HiRISE ARD

### DIFF
--- a/datasets/nasa-usgs-mars-hirise.yaml
+++ b/datasets/nasa-usgs-mars-hirise.yaml
@@ -1,0 +1,41 @@
+Name: NASA / USGS Uncontrolled HiRISE RDRs
+Description: |
+  HiRISE description.
+Documentation: https://stac.astrogeology.usgs.gov/docs/data/mars/hirise
+Contact: https://answers.usgs.gov/
+ManagedBy: "[NASA](https://www.nasa.gov)"
+UpdateFrequency: HiRISE data updated as new releases are made to the Planetary Data System.
+Tags:
+  - aws-pds
+  - planetary
+  - satellite imagery
+  - stac
+  - cog
+License: "[CC0 1.0](https://creativecommons.org/publicdomain/zero/1.0/)"
+Citation: 
+Resources:
+  - Description: Scenes and metadata
+    ARN: arn:aws:s3:::astrogeo-ard/mars/mro/hirise/uncontrolled_observations/
+    Region: us-west-2
+    Type: S3 Bucket
+    Explore:
+      - '[STAC Catalog](https://stac.astrogeology.usgs.gov/browser-dev/#/collections/mro_hirise_uncontrolled_observations)'
+DataAtWork:
+  Tutorials:
+    - Title: "Discovering and Downloading Data via the Command Line"
+      URL: https://stac.astrogeology.usgs.gov/docs/tutorials/cli/
+      AuthorName: J. Laura
+      AuthorURL: https://astrogeology.usgs.gov
+    - Title: "Discovering and Downloading Data with Python"
+      URL: https://stac.astrogeology.usgs.gov/docs/tutorials/basicpython/
+      AuthorName: J. Laura
+      AuthorURL: https://astrogeology.usgs.gov
+    - Title: "Querying for Data in an ROI and Loading it into QGIS"
+      URL: https://stac.astrogeology.usgs.gov/docs/examples/to_qgis/
+      AuthorName: J. Laura
+      AuthorURL: https://astrogeology.usgs.gov
+  Tools & Applications:
+    - Title: PySTAC Client
+      URL: https://github.com/stac-utils/pystac-client
+      AuthorName: PySTAC-Client Contributors
+      AuthorURL: https://github.com/stac-utils/pystac-client/graphs/contributors

--- a/datasets/nasa-usgs-mars-hirise.yaml
+++ b/datasets/nasa-usgs-mars-hirise.yaml
@@ -1,10 +1,10 @@
 Name: NASA / USGS Uncontrolled HiRISE RDRs
 Description: |
-    These uncontrolled High Resolution Imaging Science Experiment (HiRISE) Reduced Data Record (RDR) observations of Mars are produced from the Planetary Data System (PDS) HiRISE RDRs generated and released by the HiRISE team. These RDRs have been converted to 32-bit Cloud Optimized GeoTiffs (COGs) to be analysis ready and cloud streamable. Data were processed from the 16-bit PDS stored RDRs and are released with lossy LERC compression. The compression error is under the calibration accuracy of the HiRISE processing pipeline. Therefore, these 32-bit COGs are effectively lossless. Data are released using simple cylindrical (planetocentric positive East, center longitude 180, 0-360 longitude domain) or a pole centered polar stereographic projection. Data are projected to the appropriate IAU WKT2 represented projection. Each observation includes a provenance.txt file describing all processing done to the PDS released RDR.
+    These uncontrolled High Resolution Imaging Science Experiment (HiRISE) Reduced Data Record (RDR) observations of Mars are produced from the Planetary Data System (PDS) HiRISE RDRs generated and released by the HiRISE team. The original derived map projected RDRs have been converted to 32-bit Cloud Optimized GeoTiffs (COGs) to be analysis ready and cloud streamable. Data were processed from the 16-bit PDS stored RDRs and are released with lossy Limited Error Raster Compression (LERC) compression. The LERC compression rate was set such that the original precision (calibration accuracy) of HiRISE images were maintained. Therefore, these 32-bit COGs are effectively lossless. Data are released using simple cylindrical (planetocentric positive East, center longitude 180, 0-360 longitude domain) or a pole centered polar stereographic projection. Data are projected to the appropriate IAU Well-known Text v2 (WKT2) represented projection. Each observation includes a provenance.txt file describing all processing done to the PDS released RDR.
 Documentation: https://stac.astrogeology.usgs.gov/docs/data/mars/hirise
 Contact: https://answers.usgs.gov/
 ManagedBy: "[NASA](https://www.nasa.gov)"
-UpdateFrequency: HiRISE data updated as new releases are made to the Planetary Data System.
+UpdateFrequency: HiRISE data will be updated as new releases are made to the Planetary Data System.
 Tags:
   - aws-pds
   - planetary

--- a/datasets/nasa-usgs-mars-hirise.yaml
+++ b/datasets/nasa-usgs-mars-hirise.yaml
@@ -12,7 +12,7 @@ Tags:
   - stac
   - cog
 License: "[CC0 1.0](https://creativecommons.org/publicdomain/zero/1.0/)"
-Citation: 
+Citation: https://doi.org/10.5066/P944DLP8
 Resources:
   - Description: Scenes and metadata
     ARN: arn:aws:s3:::astrogeo-ard/mars/mro/hirise/uncontrolled_observations/

--- a/datasets/nasa-usgs-mars-hirise.yaml
+++ b/datasets/nasa-usgs-mars-hirise.yaml
@@ -1,7 +1,7 @@
 Name: NASA / USGS Uncontrolled HiRISE RDRs
 Description: |
     These uncontrolled High Resolution Imaging Science Experiment (HiRISE) Reduced Data Record (RDR) observations of Mars are produced from the Planetary Data System (PDS) HiRISE RDRs generated and released by the HiRISE team. The original derived map projected RDRs have been converted to 32-bit Cloud Optimized GeoTiffs (COGs) to be analysis ready and cloud streamable. Data were processed from the 16-bit PDS stored RDRs and are released with lossy Limited Error Raster Compression (LERC) compression. The LERC compression rate was set such that the original precision (calibration accuracy) of HiRISE images were maintained. Therefore, these 32-bit COGs are effectively lossless. Data are released using simple cylindrical (planetocentric positive East, center longitude 180, 0-360 longitude domain) or a pole centered polar stereographic projection. Data are projected to the appropriate IAU Well-known Text v2 (WKT2) represented projection. Each observation includes a provenance.txt file describing all processing done to the PDS released RDR.
-Documentation: https://stac.astrogeology.usgs.gov/docs/data/mars/hirise
+Documentation: https://stac.astrogeology.usgs.gov/docs/data/mars/uncontrolled_hirise/
 Contact: https://answers.usgs.gov/
 ManagedBy: "[NASA](https://www.nasa.gov)"
 UpdateFrequency: HiRISE data will be updated as new releases are made to the Planetary Data System.

--- a/datasets/nasa-usgs-mars-hirise.yaml
+++ b/datasets/nasa-usgs-mars-hirise.yaml
@@ -1,6 +1,6 @@
 Name: NASA / USGS Uncontrolled HiRISE RDRs
 Description: |
-  HiRISE description.
+    These uncontrolled High Resolution Imaging Science Experiment (HiRISE) Reduced Data Record (RDR) observations of Mars are produced from the Planetary Data System (PDS) HiRISE RDRs generated and released by the HiRISE team. These RDRs have been converted to 32-bit Cloud Optimized GeoTiffs (COGs) to be analysis ready and cloud streamable. Data were processed from the 16-bit PDS stored RDRs and are released with lossy LERC compression. The compression error is under the calibration accuracy of the HiRISE processing pipeline. Therefore, these 32-bit COGs are effectively lossless. Data are released using simple cylindrical (planetocentric positive East, center longitude 180, 0-360 longitude domain) or a pole centered polar stereographic projection. Data are projected to the appropriate IAU WKT2 represented projection. Each observation includes a provenance.txt file describing all processing done to the PDS released RDR.
 Documentation: https://stac.astrogeology.usgs.gov/docs/data/mars/hirise
 Contact: https://answers.usgs.gov/
 ManagedBy: "[NASA](https://www.nasa.gov)"
@@ -15,7 +15,7 @@ License: "[CC0 1.0](https://creativecommons.org/publicdomain/zero/1.0/)"
 Citation: https://doi.org/10.5066/P944DLP8
 Resources:
   - Description: Scenes and metadata
-    ARN: arn:aws:s3:::astrogeo-ard/mars/mro/hirise/uncontrolled_observations/
+    ARN: arn:aws:s3:::astrogeo-ard/mars/mro/hirise/uncontrolled_rdr_observations/
     Region: us-west-2
     Type: S3 Bucket
     Explore:


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This entry is for 155k+ high resolution images of Mars from the Mars Reconnaissance Oribter (MRO) High Resolution Science Experiment (HiRISE) instrument. Data are 0.25 - 1m per pixel in RED and false color.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
