### PR TITLE
Add NASA Helio Data Project dataset

### DIFF
--- a/datasets/sdoml-fdl.yaml
+++ b/datasets/sdoml-fdl.yaml
@@ -14,7 +14,7 @@ Resources:
   - Description: The v1 dataset includes AIA observations 2010-2018 and v2 includes AIA observations 2010-2020 in all 10 wavebands (94A, 131A, 171A, 193A, 211A, 304A, 335A, 1600A, 1700A, 4500A), with 512x512 resolution and 6 minutes cadence; HMI vector magnetic field observations 2010-2018 in Bx, By, and Bz components, with 512x512 resolution and 12 minutes cadence; The EVE observations in 39 wavelengths from 2010-05-01 to 2014-05-26, with 10 seconds cadence.
     ARN: arn:aws:s3:::gov-nasa-hdrl-data1/contrib/fdl-sdoml/
     Region:
-    Type: S3 bucket
+    Type: S3 Bucket
     Explore:
 DataAtWork:
   Tutorials: 

--- a/datasets/sdoml-fdl.yaml
+++ b/datasets/sdoml-fdl.yaml
@@ -5,16 +5,16 @@ Contact: Meng Jin (jinmeng@lmsal.com) and Paul Wright (paul@pauljwright.co.uk)
 ManagedBy: "[NASA](http://www.nasa.gov/)"
 UpdateFrequency: N/A (The IDL/Python scripts for generating the datasets are published online, which can be used by users to generate the v1 dataset after 2018 and v2 dataset after 2020)
 Tags:
-  - aws-pds
-  - machine learning
-  - NASA SMD AI
+  -aws-pds
+  -machine learning
+  -NASA SMD AI
 License: There are no restrictions on the use of this data.
 Citation:
 Resources:
   - Description: The v1 dataset includes AIA observations 2010-2018 and v2 includes AIA observations 2010-2020 in all 10 wavebands (94A, 131A, 171A, 193A, 211A, 304A, 335A, 1600A, 1700A, 4500A), with 512x512 resolution and 6 minutes cadence; HMI vector magnetic field observations 2010-2018 in Bx, By, and Bz components, with 512x512 resolution and 12 minutes cadence; The EVE observations in 39 wavelengths from 2010-05-01 to 2014-05-26, with 10 seconds cadence.
-    ARN: arn:aws:s3:::gov-nasa-hdrl-data1/contrib
+    ARN: arn:aws:s3::: gov-nasa-hdrl-data1/contrib/fdl-sdoml/    
     Region:
-    Type: S3 Bucket
+    Type: S3 bucket
     Explore:
 DataAtWork:
   Tutorials: 
@@ -26,21 +26,13 @@ DataAtWork:
       Services:
   Tools & Applications:
     - Title: Scripts for generating the SDOMLv1 dataset
-      URL: https://github.com/SDOML/SDOML
-      AuthorName:
-      AuthorURL:
+      URL:https://github.com/SDOML/SDOML
     - Title: Scripts for generating the SDOMLv2 dataset
-      URL: https://github.com/SDOML/SDOMLv2
-      AuthorName:
-      AuthorURL: 
+      URL:https://github.com/SDOML/SDOMLv2
     - Title: ML applications based on the SDOMLv1 dataset
       URL: https://gitlab.com/frontierdevelopmentlab/living-with-our-star/expanding-sdo-capabilities
-      AuthorName:
-      AuthorURL:
     - Title: ML applications based on the SDOMLv2 dataset
       URL: https://github.com/spaceml-org/helionb-sdoml
-      AuthorName:
-      AuthorURL:
   Publications:
     - Title: A Machine-learning Data Set Prepared from the NASA Solar Dynamics Observatory Mission
       URL: http://adsabs.harvard.edu/abs/2019ApJS..242....7G
@@ -48,3 +40,4 @@ DataAtWork:
       AuthorURL:
 DeprecatedNotice:
 ADXCategories:
+  -    

--- a/datasets/sdoml-fdl.yaml
+++ b/datasets/sdoml-fdl.yaml
@@ -5,14 +5,14 @@ Contact: Meng Jin (jinmeng@lmsal.com) and Paul Wright (paul@pauljwright.co.uk)
 ManagedBy: "[NASA](http://www.nasa.gov/)"
 UpdateFrequency: N/A (The IDL/Python scripts for generating the datasets are published online, which can be used by users to generate the v1 dataset after 2018 and v2 dataset after 2020)
 Tags:
-  -aws-pds
-  -machine learning
-  -NASA SMD AI
+  - aws-pds
+  - machine learning
+  - NASA SMD AI
 License: There are no restrictions on the use of this data.
 Citation:
 Resources:
   - Description: The v1 dataset includes AIA observations 2010-2018 and v2 includes AIA observations 2010-2020 in all 10 wavebands (94A, 131A, 171A, 193A, 211A, 304A, 335A, 1600A, 1700A, 4500A), with 512x512 resolution and 6 minutes cadence; HMI vector magnetic field observations 2010-2018 in Bx, By, and Bz components, with 512x512 resolution and 12 minutes cadence; The EVE observations in 39 wavelengths from 2010-05-01 to 2014-05-26, with 10 seconds cadence.
-    ARN: arn:aws:s3::: gov-nasa-hdrl-data1/contrib    
+    ARN: arn:aws:s3:::gov-nasa-hdrl-data1/contrib    
     Region:
     Type: S3 bucket
     Explore:
@@ -26,11 +26,11 @@ DataAtWork:
       Services:
   Tools & Applications:
     - Title: Scripts for generating the SDOMLv1 dataset
-      URL:https://github.com/SDOML/SDOML
+      URL: https://github.com/SDOML/SDOML
       AuthorName:
       AuthorURL:
     - Title: Scripts for generating the SDOMLv2 dataset
-      URL:https://github.com/SDOML/SDOMLv2
+      URL: https://github.com/SDOML/SDOMLv2
       AuthorName:
       AuthorURL: 
     - Title: ML applications based on the SDOMLv1 dataset

--- a/datasets/sdoml-fdl.yaml
+++ b/datasets/sdoml-fdl.yaml
@@ -12,7 +12,7 @@ License: There are no restrictions on the use of this data.
 Citation:
 Resources:
   - Description: The v1 dataset includes AIA observations 2010-2018 and v2 includes AIA observations 2010-2020 in all 10 wavebands (94A, 131A, 171A, 193A, 211A, 304A, 335A, 1600A, 1700A, 4500A), with 512x512 resolution and 6 minutes cadence; HMI vector magnetic field observations 2010-2018 in Bx, By, and Bz components, with 512x512 resolution and 12 minutes cadence; The EVE observations in 39 wavelengths from 2010-05-01 to 2014-05-26, with 10 seconds cadence.
-    ARN: arn:aws:s3:::gov-nasa-hdrl-data1/contrib    
+    ARN: arn:aws:s3:::gov-nasa-hdrl-data1/contrib
     Region:
     Type: S3 bucket
     Explore:

--- a/datasets/sdoml-fdl.yaml
+++ b/datasets/sdoml-fdl.yaml
@@ -14,7 +14,7 @@ Resources:
   - Description: The v1 dataset includes AIA observations 2010-2018 and v2 includes AIA observations 2010-2020 in all 10 wavebands (94A, 131A, 171A, 193A, 211A, 304A, 335A, 1600A, 1700A, 4500A), with 512x512 resolution and 6 minutes cadence; HMI vector magnetic field observations 2010-2018 in Bx, By, and Bz components, with 512x512 resolution and 12 minutes cadence; The EVE observations in 39 wavelengths from 2010-05-01 to 2014-05-26, with 10 seconds cadence.
     ARN: arn:aws:s3:::gov-nasa-hdrl-data1/contrib
     Region:
-    Type: S3 bucket
+    Type: S3 Bucket
     Explore:
 DataAtWork:
   Tutorials: 

--- a/datasets/sdoml-fdl.yaml
+++ b/datasets/sdoml-fdl.yaml
@@ -12,7 +12,7 @@ License: There are no restrictions on the use of this data.
 Citation:
 Resources:
   - Description: The v1 dataset includes AIA observations 2010-2018 and v2 includes AIA observations 2010-2020 in all 10 wavebands (94A, 131A, 171A, 193A, 211A, 304A, 335A, 1600A, 1700A, 4500A), with 512x512 resolution and 6 minutes cadence; HMI vector magnetic field observations 2010-2018 in Bx, By, and Bz components, with 512x512 resolution and 12 minutes cadence; The EVE observations in 39 wavelengths from 2010-05-01 to 2014-05-26, with 10 seconds cadence.
-    ARN: arn:aws:s3:::gov-nasa-hdrl-data1/contrib/fdl-sdoml/    
+    ARN: arn:aws:s3:::gov-nasa-hdrl-data1/contrib/fdl-sdoml/
     Region:
     Type: S3 bucket
     Explore:

--- a/datasets/sdoml-fdl.yaml
+++ b/datasets/sdoml-fdl.yaml
@@ -1,0 +1,51 @@
+Name: Solar Dynamics Observatory (SDO) Machine Learning Dataset
+Description: We present a curated dataset from the NASA Solar Dynamics Observatory (SDO) mission in a format suitable for machine learning (ML) research. Beginning from level 1 scientific products, we have preprocessed this data by down-sampling AIA and HMI images from 4096 × 4096 to 512 × 512 pixels, removed QUALITY ne 0 observations, corrected for instrumental degradation over time, and applied exposure corrections. We also have ensured that both AIA and HMI data are spatially colocated, have identical angular resolutions, and that all instruments are chronosynchronous. The v1 version of the dataset is available in both .npz and .mm format and the v2 version is based on the v1 version, but converted to a cloud friendly Zarr format with full FITS header/keyword information. In addition, the degradation correction has been updated using latest calibration (v9). We anticipate this curated dataset will facilitate machine learning research in heliophysics and the physical sciences generally, increasing the scientific return of the SDO mission. This work is a deliverable of the 2018 NASA Frontier Development Lab program and also supported by SpaceML.org. Data from 2010-2018 are available for SDOMLv1 and data from 2010-2020 are available for SDOMLv2.
+Documentation: https://github.com/SDOML/sdoml.github.io
+Contact: Meng Jin (jinmeng@lmsal.com) and Paul Wright (paul@pauljwright.co.uk) 
+ManagedBy: "[NASA](http://www.nasa.gov/)"
+UpdateFrequency: N/A (The IDL/Python scripts for generating the datasets are published online, which can be used by users to generate the v1 dataset after 2018 and v2 dataset after 2020)
+Tags:
+  -aws-pds
+  -machine learning
+  -NASA SMD AI
+License: There are no restrictions on the use of this data.
+Citation:
+Resources:
+  - Description: The v1 dataset includes AIA observations 2010-2018 and v2 includes AIA observations 2010-2020 in all 10 wavebands (94A, 131A, 171A, 193A, 211A, 304A, 335A, 1600A, 1700A, 4500A), with 512x512 resolution and 6 minutes cadence; HMI vector magnetic field observations 2010-2018 in Bx, By, and Bz components, with 512x512 resolution and 12 minutes cadence; The EVE observations in 39 wavelengths from 2010-05-01 to 2014-05-26, with 10 seconds cadence.
+    ARN: arn:aws:s3::: gov-nasa-hdrl-data1/contrib    
+    Region:
+    Type: S3 bucket
+    Explore:
+DataAtWork:
+  Tutorials: 
+    - Title: SDOMLv2 Github
+      URL: https://github.com/spaceml-org/helionb-sdoml/tree/main/notebooks/01_sdoml_dataset_2018
+      NotebookURL:
+      AuthorName:
+      AuthorURL:
+      Services:
+  Tools & Applications:
+    - Title: Scripts for generating the SDOMLv1 dataset
+      URL:https://github.com/SDOML/SDOML
+      AuthorName:
+      AuthorURL:
+    - Title: Scripts for generating the SDOMLv2 dataset
+      URL:https://github.com/SDOML/SDOMLv2
+      AuthorName:
+      AuthorURL: 
+    - Title: ML applications based on the SDOMLv1 dataset
+      URL: https://gitlab.com/frontierdevelopmentlab/living-with-our-star/expanding-sdo-capabilities
+      AuthorName:
+      AuthorURL:
+    - Title: ML applications based on the SDOMLv2 dataset
+      URL: https://github.com/spaceml-org/helionb-sdoml
+      AuthorName:
+      AuthorURL:
+  Publications:
+    - Title: A Machine-learning Data Set Prepared from the NASA Solar Dynamics Observatory Mission
+      URL: http://adsabs.harvard.edu/abs/2019ApJS..242....7G
+      AuthorName: Galvez, Richard search by orcid ; Fouhey, David F. search by orcid ; Jin, Meng search by orcid ; Szenicer, Alexandre; et al
+      AuthorURL:
+DeprecatedNotice:
+ADXCategories:
+  -    

--- a/datasets/sdoml-fdl.yaml
+++ b/datasets/sdoml-fdl.yaml
@@ -48,4 +48,3 @@ DataAtWork:
       AuthorURL:
 DeprecatedNotice:
 ADXCategories:
-  -    

--- a/datasets/sdoml-fdl.yaml
+++ b/datasets/sdoml-fdl.yaml
@@ -14,19 +14,25 @@ Resources:
   - Description: The v1 dataset includes AIA observations 2010-2018 and v2 includes AIA observations 2010-2020 in all 10 wavebands (94A, 131A, 171A, 193A, 211A, 304A, 335A, 1600A, 1700A, 4500A), with 512x512 resolution and 6 minutes cadence; HMI vector magnetic field observations 2010-2018 in Bx, By, and Bz components, with 512x512 resolution and 12 minutes cadence; The EVE observations in 39 wavelengths from 2010-05-01 to 2014-05-26, with 10 seconds cadence.
     ARN: arn:aws:s3:::gov-nasa-hdrl-data1/contrib/fdl-sdoml/
     Type: S3 Bucket
+    Region: 
 DataAtWork:
   Tutorials: 
     - Title: SDOMLv2 Github
       URL: https://github.com/spaceml-org/helionb-sdoml/tree/main/notebooks/01_sdoml_dataset_2018
+      AuthorName: 
   Tools & Applications:
     - Title: Scripts for generating the SDOMLv1 dataset
       URL: https://github.com/SDOML/SDOML
+      AuthorName: 
     - Title: Scripts for generating the SDOMLv2 dataset
       URL: https://github.com/SDOML/SDOMLv2
+      AuthorName: 
     - Title: ML applications based on the SDOMLv1 dataset
       URL: https://gitlab.com/frontierdevelopmentlab/living-with-our-star/expanding-sdo-capabilities
+      AuthorName: 
     - Title: ML applications based on the SDOMLv2 dataset
       URL: https://github.com/spaceml-org/helionb-sdoml
+      AuthorName: 
   Publications:
     - Title: A Machine-learning Data Set Prepared from the NASA Solar Dynamics Observatory Mission
       URL: http://adsabs.harvard.edu/abs/2019ApJS..242....7G

--- a/datasets/sdoml-fdl.yaml
+++ b/datasets/sdoml-fdl.yaml
@@ -13,17 +13,11 @@ Citation:
 Resources:
   - Description: The v1 dataset includes AIA observations 2010-2018 and v2 includes AIA observations 2010-2020 in all 10 wavebands (94A, 131A, 171A, 193A, 211A, 304A, 335A, 1600A, 1700A, 4500A), with 512x512 resolution and 6 minutes cadence; HMI vector magnetic field observations 2010-2018 in Bx, By, and Bz components, with 512x512 resolution and 12 minutes cadence; The EVE observations in 39 wavelengths from 2010-05-01 to 2014-05-26, with 10 seconds cadence.
     ARN: arn:aws:s3:::gov-nasa-hdrl-data1/contrib/fdl-sdoml/
-    Region:
     Type: S3 Bucket
-    Explore:
 DataAtWork:
   Tutorials: 
     - Title: SDOMLv2 Github
       URL: https://github.com/spaceml-org/helionb-sdoml/tree/main/notebooks/01_sdoml_dataset_2018
-      NotebookURL:
-      AuthorName:
-      AuthorURL:
-      Services:
   Tools & Applications:
     - Title: Scripts for generating the SDOMLv1 dataset
       URL: https://github.com/SDOML/SDOML
@@ -37,6 +31,5 @@ DataAtWork:
     - Title: A Machine-learning Data Set Prepared from the NASA Solar Dynamics Observatory Mission
       URL: http://adsabs.harvard.edu/abs/2019ApJS..242....7G
       AuthorName: Galvez, Richard search by orcid ; Fouhey, David F. search by orcid ; Jin, Meng search by orcid ; Szenicer, Alexandre; et al
-      AuthorURL:
 DeprecatedNotice:
 ADXCategories: 

--- a/datasets/sdoml-fdl.yaml
+++ b/datasets/sdoml-fdl.yaml
@@ -12,7 +12,7 @@ License: There are no restrictions on the use of this data.
 Citation:
 Resources:
   - Description: The v1 dataset includes AIA observations 2010-2018 and v2 includes AIA observations 2010-2020 in all 10 wavebands (94A, 131A, 171A, 193A, 211A, 304A, 335A, 1600A, 1700A, 4500A), with 512x512 resolution and 6 minutes cadence; HMI vector magnetic field observations 2010-2018 in Bx, By, and Bz components, with 512x512 resolution and 12 minutes cadence; The EVE observations in 39 wavelengths from 2010-05-01 to 2014-05-26, with 10 seconds cadence.
-    ARN: arn:aws:s3::: gov-nasa-hdrl-data1/contrib/fdl-sdoml/    
+    ARN: arn:aws:s3:::gov-nasa-hdrl-data1/contrib/fdl-sdoml/    
     Region:
     Type: S3 bucket
     Explore:

--- a/datasets/sdoml-fdl.yaml
+++ b/datasets/sdoml-fdl.yaml
@@ -39,5 +39,4 @@ DataAtWork:
       AuthorName: Galvez, Richard search by orcid ; Fouhey, David F. search by orcid ; Jin, Meng search by orcid ; Szenicer, Alexandre; et al
       AuthorURL:
 DeprecatedNotice:
-ADXCategories:
-  -    
+ADXCategories: 

--- a/datasets/sdoml-fdl.yaml
+++ b/datasets/sdoml-fdl.yaml
@@ -26,9 +26,9 @@ DataAtWork:
       Services:
   Tools & Applications:
     - Title: Scripts for generating the SDOMLv1 dataset
-      URL:https://github.com/SDOML/SDOML
+      URL: https://github.com/SDOML/SDOML
     - Title: Scripts for generating the SDOMLv2 dataset
-      URL:https://github.com/SDOML/SDOMLv2
+      URL: https://github.com/SDOML/SDOMLv2
     - Title: ML applications based on the SDOMLv1 dataset
       URL: https://gitlab.com/frontierdevelopmentlab/living-with-our-star/expanding-sdo-capabilities
     - Title: ML applications based on the SDOMLv2 dataset

--- a/datasets/sdoml-fdl.yaml
+++ b/datasets/sdoml-fdl.yaml
@@ -5,9 +5,9 @@ Contact: Meng Jin (jinmeng@lmsal.com) and Paul Wright (paul@pauljwright.co.uk)
 ManagedBy: "[NASA](http://www.nasa.gov/)"
 UpdateFrequency: N/A (The IDL/Python scripts for generating the datasets are published online, which can be used by users to generate the v1 dataset after 2018 and v2 dataset after 2020)
 Tags:
-  -aws-pds
-  -machine learning
-  -NASA SMD AI
+  - aws-pds
+  - machine learning
+  - NASA SMD AI
 License: There are no restrictions on the use of this data.
 Citation:
 Resources:


### PR DESCRIPTION
Solar Dynamics Observatory Machine Learning Dataset Version 1 & 2. This dataset should also be linked to the NASA collab space at https://registry.opendata.aws/collab/nasa/

*Issue #, if available:*

*Description of changes:*
Adding new dataset for NASA Helio

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
