### PR TITLE
Add two NASA astrophysics datasets

### DIFF
--- a/datasets/apd_galaxymorph.yaml
+++ b/datasets/apd_galaxymorph.yaml
@@ -20,7 +20,6 @@ Resources:
     Explore:
 DataAtWork:
   Publications:
-  - Title:|
-    Galaxy Zoo: morphological classifications for 120 000 galaxies in HST legacy imaging
-    URL: https://academic.oup.com/mnras/article/464/4/4176/2527878
-    AuthorName: Kyle W. Willett, Melanie A. Galloway, Steven P. Bamford, Chris J. Lintott, Karen L. Masters, Claudia Scarlata, B. D. Simmons, Melanie Beck, Carolin N. Cardamone, Edmond Cheung, Edward M. Edmondson, Lucy F. Fortson, Roger L. Griffith, Boris Häußler, Anna Han, Ross Hart, Thomas Melvin, Michael Parrish, Kevin Schawinski, R. J. Smethurst, Arfon M. Smith
+    - Title: Galaxy Zoo: morphological classifications for 120 000 galaxies in HST legacy imaging
+      URL: https://academic.oup.com/mnras/article/464/4/4176/2527878
+      AuthorName: Kyle W. Willett, Melanie A. Galloway, Steven P. Bamford, Chris J. Lintott, Karen L. Masters, Claudia Scarlata, B. D. Simmons, Melanie Beck, Carolin N. Cardamone, Edmond Cheung, Edward M. Edmondson, Lucy F. Fortson, Roger L. Griffith, Boris Häußler, Anna Han, Ross Hart, Thomas Melvin, Michael Parrish, Kevin Schawinski, R. J. Smethurst, Arfon M. Smith

--- a/datasets/apd_galaxymorph.yaml
+++ b/datasets/apd_galaxymorph.yaml
@@ -20,6 +20,7 @@ Resources:
     Explore:
 DataAtWork:
   Publications:
-  - Title: Galaxy Zoo: morphological classifications for 120 000 galaxies in HST legacy imaging
+  - Title:|
+   Galaxy Zoo: morphological classifications for 120 000 galaxies in HST legacy imaging
     URL: https://academic.oup.com/mnras/article/464/4/4176/2527878
     AuthorName: Kyle W. Willett, Melanie A. Galloway, Steven P. Bamford, Chris J. Lintott, Karen L. Masters, Claudia Scarlata, B. D. Simmons, Melanie Beck, Carolin N. Cardamone, Edmond Cheung, Edward M. Edmondson, Lucy F. Fortson, Roger L. Griffith, Boris Häußler, Anna Han, Ross Hart, Thomas Melvin, Michael Parrish, Kevin Schawinski, R. J. Smethurst, Arfon M. Smith

--- a/datasets/apd_galaxymorph.yaml
+++ b/datasets/apd_galaxymorph.yaml
@@ -21,6 +21,6 @@ Resources:
 DataAtWork:
   Publications:
   - Title:|
-   Galaxy Zoo: morphological classifications for 120 000 galaxies in HST legacy imaging
+    Galaxy Zoo: morphological classifications for 120 000 galaxies in HST legacy imaging
     URL: https://academic.oup.com/mnras/article/464/4/4176/2527878
     AuthorName: Kyle W. Willett, Melanie A. Galloway, Steven P. Bamford, Chris J. Lintott, Karen L. Masters, Claudia Scarlata, B. D. Simmons, Melanie Beck, Carolin N. Cardamone, Edmond Cheung, Edward M. Edmondson, Lucy F. Fortson, Roger L. Griffith, Boris Häußler, Anna Han, Ross Hart, Thomas Melvin, Michael Parrish, Kevin Schawinski, R. J. Smethurst, Arfon M. Smith

--- a/datasets/apd_galaxymorph.yaml
+++ b/datasets/apd_galaxymorph.yaml
@@ -1,5 +1,6 @@
 Name: Astrophysics Division Galaxy Morphology Benchmark Dataset
-Description: Hubble Space Telescope imaging data and associated identification labels for galaxy morphology derived from citizen scientist labels from the Galaxy Zoo: Hubble project.
+Description: |
+Hubble Space Telescope imaging data and associated identification labels for galaxy morphology derived from citizen scientist labels from the Galaxy Zoo: Hubble project.
 Documentation: https://github.com/erinleeryan/nasa_astro_aiml/tree/main/galaxymorphology
 Contact: Roopesh.Ojha@nasa.gov
 ManagedBy: "[NASA](https://osdr.nasa.gov/)"

--- a/datasets/apd_galaxymorph.yaml
+++ b/datasets/apd_galaxymorph.yaml
@@ -20,6 +20,6 @@ Resources:
     Explore:
 DataAtWork:
   Publications:
-    - Title: 'Galaxy Zoo: morphological classifications for 120 000 galaxies in HST legacy imaging'
+    - Title: "Galaxy Zoo: morphological classifications for 120 000 galaxies in HST legacy imaging"
       URL: https://academic.oup.com/mnras/article/464/4/4176/2527878
       AuthorName: Kyle W. Willett, Melanie A. Galloway, Steven P. Bamford, Chris J. Lintott, Karen L. Masters, Claudia Scarlata, B. D. Simmons, Melanie Beck, Carolin N. Cardamone, Edmond Cheung, Edward M. Edmondson, Lucy F. Fortson, Roger L. Griffith, Boris Häußler, Anna Han, Ross Hart, Thomas Melvin, Michael Parrish, Kevin Schawinski, R. J. Smethurst, Arfon M. Smith

--- a/datasets/apd_galaxymorph.yaml
+++ b/datasets/apd_galaxymorph.yaml
@@ -1,6 +1,6 @@
 Name: Astrophysics Division Galaxy Morphology Benchmark Dataset
 Description: |
-Hubble Space Telescope imaging data and associated identification labels for galaxy morphology derived from citizen scientist labels from the Galaxy Zoo: Hubble project.
+ Hubble Space Telescope imaging data and associated identification labels for galaxy morphology derived from citizen scientist labels from the Galaxy Zoo: Hubble project.
 Documentation: https://github.com/erinleeryan/nasa_astro_aiml/tree/main/galaxymorphology
 Contact: Roopesh.Ojha@nasa.gov
 ManagedBy: "[NASA](https://osdr.nasa.gov/)"

--- a/datasets/apd_galaxymorph.yaml
+++ b/datasets/apd_galaxymorph.yaml
@@ -1,0 +1,24 @@
+Name: Astrophysics Division Galaxy Morphology Benchmark Dataset
+Description: Hubble Space Telescope imaging data and associated identification labels for galaxy morphology derived from citizen scientist labels from the Galaxy Zoo: Hubble project.
+Documentation: https://github.com/erinleeryan/nasa_astro_aiml/tree/main/galaxymorphology
+Contact: Roopesh.Ojha@nasa.gov
+ManagedBy: "[NASA](https://osdr.nasa.gov/)"
+UpdateFrequency: No updates
+Tags:
+  - aws-pds
+  - astronomy
+  - machine learning
+  - satellite imagery
+  - NASA SMD AI
+License: There are no restrictions on the use of this data.
+Resources: 
+  - Description: NASA APD Galaxy Morphology dataset
+    ARN: arn:aws:s3:::nasa-apd-galaxymorph
+    Region: us-west-2
+    Type: S3 Bucket
+    Explore:
+DataAtWork:
+  Publications:
+  - Title: Galaxy Zoo: morphological classifications for 120 000 galaxies in HST legacy imaging
+    URL: https://academic.oup.com/mnras/article/464/4/4176/2527878
+    AuthorName: Kyle W. Willett, Melanie A. Galloway, Steven P. Bamford, Chris J. Lintott, Karen L. Masters, Claudia Scarlata, B. D. Simmons, Melanie Beck, Carolin N. Cardamone, Edmond Cheung, Edward M. Edmondson, Lucy F. Fortson, Roger L. Griffith, Boris Häußler, Anna Han, Ross Hart, Thomas Melvin, Michael Parrish, Kevin Schawinski, R. J. Smethurst, Arfon M. Smith

--- a/datasets/apd_galaxymorph.yaml
+++ b/datasets/apd_galaxymorph.yaml
@@ -20,6 +20,6 @@ Resources:
     Explore:
 DataAtWork:
   Publications:
-    - Title: Galaxy Zoo: morphological classifications for 120 000 galaxies in HST legacy imaging
+    - Title: 'Galaxy Zoo: morphological classifications for 120 000 galaxies in HST legacy imaging'
       URL: https://academic.oup.com/mnras/article/464/4/4176/2527878
       AuthorName: Kyle W. Willett, Melanie A. Galloway, Steven P. Bamford, Chris J. Lintott, Karen L. Masters, Claudia Scarlata, B. D. Simmons, Melanie Beck, Carolin N. Cardamone, Edmond Cheung, Edward M. Edmondson, Lucy F. Fortson, Roger L. Griffith, Boris Häußler, Anna Han, Ross Hart, Thomas Melvin, Michael Parrish, Kevin Schawinski, R. J. Smethurst, Arfon M. Smith

--- a/datasets/apd_galaxysegmentation.yaml
+++ b/datasets/apd_galaxysegmentation.yaml
@@ -20,9 +20,9 @@ Resources:
     Explore:
 DataAtWork:
   Publications:
-    - Title: 'Galaxy Zoo: 3D – crowdsourced bar, spiral, and foreground star masks for MaNGA target galaxies'
+    - Title: "Galaxy Zoo: 3D – crowdsourced bar, spiral, and foreground star masks for MaNGA target galaxies"
       URL: https://academic.oup.com/mnras/article/507/3/3923/6347355
       AuthorName: Karen L Masters, Coleman Krawczyk, Shoaib Shamsi, Alexander Todd, Daniel Finnegan, Matthew Bershady, Kevin Bundy, Brian Cherinka, Amelia Fraser-McKelvie, Dhanesh Krishnarao, Sandor Kruk, Richard R Lane, David Law, Chris Lintott, Michael Merrifield, Brooke Simmons, Anne-Marie Weijmans, Renbin Yan
-    - Title: Pan-STARRS Pixel Processing: Detrending, Warping, Stacking
+    - Title: "Pan-STARRS Pixel Processing: Detrending, Warping, Stacking"
       URL: https://iopscience.iop.org/article/10.3847/1538-4365/abb82b
       AuthorName: C. Z. Waters, E. A. Magnier, P. A. Price, K. C. Chambers, W. S. Burgett, P. W. Draper, H. A. Flewelling, K. W. Hodapp, M. E. Huber, R. Jedicke, N. Kaiser, R.-P. Kudritzki, R. H. Lupton, N. Metcalfe, A. Rest, W. E. Sweeney, J. L. Tonry, R. J. Wainscoat, and W. M. Wood-Vase

--- a/datasets/apd_galaxysegmentation.yaml
+++ b/datasets/apd_galaxysegmentation.yaml
@@ -20,7 +20,8 @@ Resources:
     Explore:
 DataAtWork:
   Publications:
-  - Title: Galaxy Zoo: 3D – crowdsourced bar, spiral, and foreground star masks for MaNGA target galaxies
+  - Title:|
+   Galaxy Zoo: 3D – crowdsourced bar, spiral, and foreground star masks for MaNGA target galaxies
     URL: https://academic.oup.com/mnras/article/507/3/3923/6347355
     AuthorName: Karen L Masters, Coleman Krawczyk, Shoaib Shamsi, Alexander Todd, Daniel Finnegan, Matthew Bershady, Kevin Bundy, Brian Cherinka, Amelia Fraser-McKelvie, Dhanesh Krishnarao, Sandor Kruk, Richard R Lane, David Law, Chris Lintott, Michael Merrifield, Brooke Simmons, Anne-Marie Weijmans, Renbin Yan
   - Title: Pan-STARRS Pixel Processing: Detrending, Warping, Stacking

--- a/datasets/apd_galaxysegmentation.yaml
+++ b/datasets/apd_galaxysegmentation.yaml
@@ -20,7 +20,7 @@ Resources:
     Explore:
 DataAtWork:
   Publications:
-    - Title: Galaxy Zoo: 3D – crowdsourced bar, spiral, and foreground star masks for MaNGA target galaxies
+    - Title: 'Galaxy Zoo: 3D – crowdsourced bar, spiral, and foreground star masks for MaNGA target galaxies'
       URL: https://academic.oup.com/mnras/article/507/3/3923/6347355
       AuthorName: Karen L Masters, Coleman Krawczyk, Shoaib Shamsi, Alexander Todd, Daniel Finnegan, Matthew Bershady, Kevin Bundy, Brian Cherinka, Amelia Fraser-McKelvie, Dhanesh Krishnarao, Sandor Kruk, Richard R Lane, David Law, Chris Lintott, Michael Merrifield, Brooke Simmons, Anne-Marie Weijmans, Renbin Yan
     - Title: Pan-STARRS Pixel Processing: Detrending, Warping, Stacking

--- a/datasets/apd_galaxysegmentation.yaml
+++ b/datasets/apd_galaxysegmentation.yaml
@@ -1,5 +1,6 @@
 Name: Astrophysics Division Galaxy Segmentation Benchmark Dataset
-Description: Pan-STARSS imaging data and associated labels for galaxy segmentation into galactic centers, galactic bars, spiral arms and foreground stars derived from citizen scientist labels from the Galaxy Zoo: 3D project.
+Description: |
+ Pan-STARSS imaging data and associated labels for galaxy segmentation into galactic centers, galactic bars, spiral arms and foreground stars derived from citizen scientist labels from the Galaxy Zoo: 3D project.
 Documentation: https://github.com/erinleeryan/nasa_astro_aiml/tree/main/galaxysegmentation
 Contact: Roopesh.Ojha@nasa.gov
 ManagedBy: "[NASA](https://osdr.nasa.gov/)"

--- a/datasets/apd_galaxysegmentation.yaml
+++ b/datasets/apd_galaxysegmentation.yaml
@@ -1,0 +1,27 @@
+Name: Astrophysics Division Galaxy Segmentation Benchmark Dataset
+Description: Pan-STARSS imaging data and associated labels for galaxy segmentation into galactic centers, galactic bars, spiral arms and foreground stars derived from citizen scientist labels from the Galaxy Zoo: 3D project.
+Documentation: https://github.com/erinleeryan/nasa_astro_aiml/tree/main/galaxysegmentation
+Contact: Roopesh.Ojha@nasa.gov
+ManagedBy: "[NASA](https://osdr.nasa.gov/)"
+UpdateFrequency: No updates
+Tags:
+  - aws-pds
+  - astronomy
+  - machine learning
+  - segmentation
+  - NASA SMD AI
+License: There are no restrictions on the use of this data.
+Resources: 
+  - Description: NASA APD Galaxy Sementation dataset consisting of astronomical FITS data format images
+    ARN: arn:aws:s3:::nasa-apd-galaxysegment
+    Region: us-west-2
+    Type: S3 Bucket
+    Explore:
+DataAtWork:
+  Publications:
+  - Title: Galaxy Zoo: 3D – crowdsourced bar, spiral, and foreground star masks for MaNGA target galaxies
+    URL: https://academic.oup.com/mnras/article/507/3/3923/6347355
+    AuthorName: Karen L Masters, Coleman Krawczyk, Shoaib Shamsi, Alexander Todd, Daniel Finnegan, Matthew Bershady, Kevin Bundy, Brian Cherinka, Amelia Fraser-McKelvie, Dhanesh Krishnarao, Sandor Kruk, Richard R Lane, David Law, Chris Lintott, Michael Merrifield, Brooke Simmons, Anne-Marie Weijmans, Renbin Yan
+  - Title: Pan-STARRS Pixel Processing: Detrending, Warping, Stacking
+    URL: https://iopscience.iop.org/article/10.3847/1538-4365/abb82b
+    AuthorName: C. Z. Waters, E. A. Magnier, P. A. Price, K. C. Chambers, W. S. Burgett, P. W. Draper, H. A. Flewelling, K. W. Hodapp, M. E. Huber, R. Jedicke, N. Kaiser, R.-P. Kudritzki, R. H. Lupton, N. Metcalfe, A. Rest, W. E. Sweeney, J. L. Tonry, R. J. Wainscoat, and W. M. Wood-Vase

--- a/datasets/apd_galaxysegmentation.yaml
+++ b/datasets/apd_galaxysegmentation.yaml
@@ -21,7 +21,7 @@ Resources:
 DataAtWork:
   Publications:
   - Title:|
-   Galaxy Zoo: 3D – crowdsourced bar, spiral, and foreground star masks for MaNGA target galaxies
+    Galaxy Zoo: 3D – crowdsourced bar, spiral, and foreground star masks for MaNGA target galaxies
     URL: https://academic.oup.com/mnras/article/507/3/3923/6347355
     AuthorName: Karen L Masters, Coleman Krawczyk, Shoaib Shamsi, Alexander Todd, Daniel Finnegan, Matthew Bershady, Kevin Bundy, Brian Cherinka, Amelia Fraser-McKelvie, Dhanesh Krishnarao, Sandor Kruk, Richard R Lane, David Law, Chris Lintott, Michael Merrifield, Brooke Simmons, Anne-Marie Weijmans, Renbin Yan
   - Title: Pan-STARRS Pixel Processing: Detrending, Warping, Stacking

--- a/datasets/apd_galaxysegmentation.yaml
+++ b/datasets/apd_galaxysegmentation.yaml
@@ -20,10 +20,9 @@ Resources:
     Explore:
 DataAtWork:
   Publications:
-  - Title:|
-    Galaxy Zoo: 3D – crowdsourced bar, spiral, and foreground star masks for MaNGA target galaxies
-    URL: https://academic.oup.com/mnras/article/507/3/3923/6347355
-    AuthorName: Karen L Masters, Coleman Krawczyk, Shoaib Shamsi, Alexander Todd, Daniel Finnegan, Matthew Bershady, Kevin Bundy, Brian Cherinka, Amelia Fraser-McKelvie, Dhanesh Krishnarao, Sandor Kruk, Richard R Lane, David Law, Chris Lintott, Michael Merrifield, Brooke Simmons, Anne-Marie Weijmans, Renbin Yan
-  - Title: Pan-STARRS Pixel Processing: Detrending, Warping, Stacking
-    URL: https://iopscience.iop.org/article/10.3847/1538-4365/abb82b
-    AuthorName: C. Z. Waters, E. A. Magnier, P. A. Price, K. C. Chambers, W. S. Burgett, P. W. Draper, H. A. Flewelling, K. W. Hodapp, M. E. Huber, R. Jedicke, N. Kaiser, R.-P. Kudritzki, R. H. Lupton, N. Metcalfe, A. Rest, W. E. Sweeney, J. L. Tonry, R. J. Wainscoat, and W. M. Wood-Vase
+    - Title: Galaxy Zoo: 3D – crowdsourced bar, spiral, and foreground star masks for MaNGA target galaxies
+      URL: https://academic.oup.com/mnras/article/507/3/3923/6347355
+      AuthorName: Karen L Masters, Coleman Krawczyk, Shoaib Shamsi, Alexander Todd, Daniel Finnegan, Matthew Bershady, Kevin Bundy, Brian Cherinka, Amelia Fraser-McKelvie, Dhanesh Krishnarao, Sandor Kruk, Richard R Lane, David Law, Chris Lintott, Michael Merrifield, Brooke Simmons, Anne-Marie Weijmans, Renbin Yan
+    - Title: Pan-STARRS Pixel Processing: Detrending, Warping, Stacking
+      URL: https://iopscience.iop.org/article/10.3847/1538-4365/abb82b
+      AuthorName: C. Z. Waters, E. A. Magnier, P. A. Price, K. C. Chambers, W. S. Burgett, P. W. Draper, H. A. Flewelling, K. W. Hodapp, M. E. Huber, R. Jedicke, N. Kaiser, R.-P. Kudritzki, R. H. Lupton, N. Metcalfe, A. Rest, W. E. Sweeney, J. L. Tonry, R. J. Wainscoat, and W. M. Wood-Vase


### PR DESCRIPTION
Adds both the Galaxy Zoo morphology AI/ML training set and the Galaxy segmentation training set

*Issue #, if available:*

*Description of changes:*
Adds two yaml files for two NASA Astrophysics Division (APD) training data sets for computer vision AI/ML.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
