### PR TITLE
Fix license link for Copernicus DEM data set

### DIFF
--- a/datasets/copernicus-dem.yaml
+++ b/datasets/copernicus-dem.yaml
@@ -19,7 +19,7 @@ Tags:
   - disaster response
   - cog
 License: |
-  GLO-30 Public and GLO-90 are available on a free basis for the general public under the terms and conditions of the Licence found [here](https://spacedata.copernicus.eu/documents/20126/0/CSCDA_ESA_Mission-specific+Annex.pdf).
+  GLO-30 Public and GLO-90 are available on a free basis for the general public under the terms and conditions of the Licence found [here](https://spacedata.copernicus.eu/documents/20123/121286/CSCDA_ESA_Mission-specific+Annex_31_Oct_22.pdf).
 Resources:
   - Description: GLO-30 Public in S3 bucket. The list of tiles covering specific countries that are not yet released to the public is available [here](https://spacedata.copernicus.eu/documents/20126/0/Non-released-tiles_GLO-30_PUBLIC_Dec.xlsx).
     ARN: arn:aws:s3:::copernicus-dem-30m


### PR DESCRIPTION
Prior license link was broken, this fixes it.
