### PR TITLE
JAXA Kaguya TC

### DIFF
--- a/datasets/jaxa-usgs-nasa-kaguya-tc.yaml
+++ b/datasets/jaxa-usgs-nasa-kaguya-tc.yaml
@@ -1,10 +1,10 @@
-Name: JAXA / USGS / NASA Kaguya/SELENE Terrain Camera Monoscopic Observations
+Name: JAXA / USGS / NASA Kaguya/SELENE Terrain Camera Observations
 Description: |
     The Japan Aerospace EXploration Agency (JAXA) SELenological and ENgineering Explorer (SELENE) mission’s Kaguya spacecraft was launched on September 14, 2007 and science operations around the Moon started October 20, 2007. The primary mission in a circular polar orbit 100-km above the surface lasted from October 20, 2007 until October 31, 2008. An extended mission was then conducted in lower orbits (averaging 50km above the surface) from November 1, 2008 until the SELENE mission ended with Kaguya impacting the Moon on June 10, 2009. These data were collected in monoscopic observing mode. To create these analysis ready data, we have taken the JAXA Data ARchives and Transmission System (DARTS) archived data, map projected the data to equirectangular or polar stereographic (pole centered) based on the center latitude of the observation, and converted to a Cloud Optimized GeoTiff (COG) for online streaming. These data use a priori spacecraft ephemerides (for the nominal mission) and improved, but not controlled spacecraft ephemerides for the extended mission. Therefore, these uncontrolled data are not guaranteed to co-register with other data sets.
 Documentation: https://stac.astrogeology.usgs.gov/docs/data/moon/kaguyatc/
 Contact: https://answers.usgs.gov/
 ManagedBy: "[NASA](https://www.nasa.gov)"
-UpdateFrequency: The Kaguya/SELENE has completed. No updates to this dataset are planned.
+UpdateFrequency: The Kaguya/SELENE mission has completed. No updates to this dataset are planned.
 Tags:
   - aws-pds
   - planetary
@@ -14,12 +14,24 @@ Tags:
 License: "[CC0 1.0](https://creativecommons.org/publicdomain/zero/1.0/)"
 Citation: https://doi.org/10.5066/P9SH5YNV
 Resources:
-  - Description: Scenes and metadata
+  - Description: Scenes and metadata for monoscopic observing mode
     ARN: arn:aws:s3:::astrogeo-ard/moon/kaguya/terrain_camera/monoscopic/uncontrolled/
     Region: us-west-2
     Type: S3 Bucket
     Explore:
       - '[STAC Catalog](https://stac.astrogeology.usgs.gov/browser-dev/#/api/collections/kaguya_terrain_camera_monoscopic_uncontrolled_observations)'
+  - Description: Scenes and metadata for stereoscopic observing mode
+    ARN: arn:aws:s3:::astrogeo-ard/moon/kaguya/terrain_camera/stereoscopic/uncontrolled/
+    Region: us-west-2
+    Type: S3 Bucket
+    Explore:
+      - '[STAC Catalog](https://stac.astrogeology.usgs.gov/browser-dev/#/api/collections/kaguya_terrain_camera_stereoscopic_uncontrolled_observations)'
+  - Description: Scenes and metadata for spectral profiler (spsupport) observing mode
+    ARN: arn:aws:s3:::astrogeo-ard/moon/kaguya/terrain_camera/spsupport/uncontrolled/
+    Region: us-west-2
+    Type: S3 Bucket
+    Explore:
+      - '[STAC Catalog](https://stac.astrogeology.usgs.gov/browser-dev/#/api/collections/kaguya_terrain_camera_spsupport_uncontrolled_observations)'
 DataAtWork:
   Tutorials:
     - Title: "Discovering and Downloading Data via the Command Line"


### PR DESCRIPTION
This PR adds the stereoscopic and sp support observing modes for the Kaguya TC sensor. Instead of having 3 separate entries for different observing modes, this is a single entry for all 3 observing modes.