### PR TITLE
Add Dark Energy Spectroscopic Instrument (DESI) dataset

### DIFF
--- a/datasets/desi-spectra.yaml
+++ b/datasets/desi-spectra.yaml
@@ -9,7 +9,7 @@ Tags:
   - cosmology
   - spectroscopy
 License: "[CC BY 4.0](https://data.desi.lbl.gov/public/edr/LICENSE.md)"
-Citation: "[DESI Collaboration et al. (2023)](https://arxiv.org/abs/2306.06308)"
+Citation: "[DESI Collaboration et al. (2023)](https://arxiv.org/abs/2306.06308) and include acknowledgments text at https://data.desi.lbl.gov/doc/acknowledgments/"
 Resources:
   - Description: DESI Early Data Release
     ARN: arn:aws:s3:::desidata-edr

--- a/datasets/desi-spectra.yaml
+++ b/datasets/desi-spectra.yaml
@@ -1,0 +1,50 @@
+Name: Dark Energy Spectroscopic Instrument (DESI) public data
+Description: The Dark Energy Spectroscopic Instrument (DESI) is building the world's largest 3D map of the universe.  This dataset contains the public data releases of the redshift catalogs and spectra of galaxies, quasars, and stars observed by DESI.
+Documentation: https://data.desi.lbl.gov/doc
+Contact: https://help.desi.lbl.gov
+ManagedBy: "[Dark Energy Spectroscopic Instrument](https://data.desi.lbl.gov)"
+UpdateFrequency: Public releases every 1-2 years
+Tags:
+  - astronomy
+  - cosmology
+  - spectroscopy
+License: "[CC BY 4.0](https://data.desi.lbl.gov/public/edr/LICENSE.md)"
+Citation: "[DESI Collaboration et al. (2023)](https://arxiv.org/abs/2306.06308)"
+Resources:
+  - Description: DESI Early Data Release
+    ARN: arn:aws:s3:::desidata-edr
+    Region: us-west-2
+    Type: S3 Bucket
+DataAtWork:
+  Tutorials:
+    - Title: Getting Started with DESI Data
+      URL: https://github.com/desihub/tutorials
+      NotebookURL: https://github.com/desihub/tutorials/blob/main/getting_started/intro_to_DESI_EDR_files.ipynb
+      AuthorName: "Ragadeepika Pucha (U.Arizona), Anthony Kremin (Berkeley Lab), Stéphanie Juneau (NOIRLab), Jaime E. Forero-Romero (Uniandes) and DESI Data Team"
+  Tools & Applications:
+    - Title: desispec
+      URL: https://github.com/desihub/desispec
+      AuthorName: DESI Data Team
+      AuthorURL: https://github.com/desihub
+    - Title: desiutil
+      URL: https://github.com/desihub/desiutil
+      AuthorName: DESI Data Team
+      AuthorURL: https://github.com/desihub
+    - Title: desitarget
+      URL: https://github.com/desihub/desitarget
+      AuthorName: DESI Data Team
+      AuthorURL: https://github.com/desihub
+    - Title: redrock
+      URL: https://github.com/desihub/redrock
+      AuthorName: DESI Data Team
+      AuthorURL: https://github.com/desihub
+  Publications:
+    - Title: The Early Data Release of the Dark Energy Spectroscopic Instrument
+      URL: https://arxiv.org/abs/2306.06308
+      AuthorName: DESI Collaboration et al
+      AuthorURL: https://desi.lbl.gov
+    - Title: The Spectroscopic Data Processing Pipeline for the Dark Energy Spectroscopic Instrument
+      URL: https://ui.adsabs.harvard.edu/abs/2023AJ....165..144G/abstract
+      AuthorName: J. Guy, S. Bailey, A. Kremin et al
+ADXCategories:
+  - Public Sector Data

--- a/tags.yaml
+++ b/tags.yaml
@@ -76,6 +76,7 @@
 - copyright monitoring
 - coronavirus
 - cover song identification
+- cosmology
 - COVID-19
 - cram
 - cromwell
@@ -327,6 +328,7 @@
 - space weather
 - SPARQL
 - speaker identification
+- spectroscopy
 - speech processing
 - speech recognition
 - speech synthesis


### PR DESCRIPTION
*Description of changes:*

This PR adds the dataset description for the Dark Energy Spectroscopic Instrument (DESI) dataset.  Currently all of the linked tutorials are for non-AWS usage of the data, but will be expanded to cover AWS usage after we have data uploaded and developed material for how to use it within the AWS ecosystem.

All entries should be valid *except* the Resources > Description > ARN, which I made up since we haven't actually uploaded anything yet.  As such, this is a draft PR until we get the dataset ready.

Especially since this is our first time contributing to the Open Data Program, any comments / feedback / requests are welcome.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
