### PR TITLE
Update maxar bucket region

### DIFF
--- a/datasets/maxar-open-data.yaml
+++ b/datasets/maxar-open-data.yaml
@@ -23,10 +23,10 @@ ManagedBy: "[Maxar](https://www.maxar.com/)"
 Resources:
   - Description: Imagery and metadata
     ARN: arn:aws:s3:::maxar-opendata
-    Region: us-east-1
+    Region: us-west-2
     Type: S3 Bucket
     Explore:
-    - '[STAC Browser](https://radiantearth.github.io/stac-browser/#/external/maxar-opendata.s3.amazonaws.com/events/catalog.json)'
+    - '[STAC Browser](https://radiantearth.github.io/stac-browser/#/external/maxar-opendata.s3.dualstack.us-west-2.amazonaws.com/events/catalog.json)'
     - '[STAC Catalog](https://stacindex.org/catalogs/maxar-open-data-catalog-ard-format#/)'
 DataAtWork:
   Tutorials:


### PR DESCRIPTION
Maxar has the changed the bucket regions and redirects to the new buckets and it breaks the cors on browsers.

![new bucket urls](https://github.com/awslabs/open-data-registry/assets/1833185/12f0a934-3dbf-4a39-ab8a-a8abf720ff4c)
![STAC Browser](https://github.com/awslabs/open-data-registry/assets/1833185/271b8435-4ce7-4580-9911-97c9720c5818)

Also updated STAC Browser urls to use dualstack for better throughput.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
