### PR TITLE
Old tutorial URL giving 404, update link to the new home

### DIFF
--- a/datasets/maf-genome.yaml
+++ b/datasets/maf-genome.yaml
@@ -35,7 +35,7 @@ Resources:
 DataAtWork:
    Tutorials:
     - Title: GRLS GWAS Tutorial
-      URL: https://morrisanimalfoundation.github.io/grGWAS/ext_docs/gwas_studies/
+      URL: https://morrisanimalfoundation.github.io/grGWAS/
       AuthorName: Tamer Mansour
    Publications: 
      - Title: "Cohort profile: The Golden Retriever Lifetime Study (GRLS)"

--- a/datasets/maf-genome.yaml
+++ b/datasets/maf-genome.yaml
@@ -35,7 +35,7 @@ Resources:
 DataAtWork:
    Tutorials:
     - Title: GRLS GWAS Tutorial
-      URL: https://maf-grls.github.io/grGWAS/1.install/
+      URL: https://morrisanimalfoundation.github.io/grGWAS/ext_docs/gwas_studies/
       AuthorName: Tamer Mansour
    Publications: 
      - Title: "Cohort profile: The Golden Retriever Lifetime Study (GRLS)"


### PR DESCRIPTION
*Description of changes:*

We moved the hosting location for the tutorial and need to update the link. the URL linked in the open data registry is currently giving a 404 error. Sorry for the extra work. The urls should all be fairly stable after this fix.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
