### PR TITLE
Update HYCOM oceantrack github and bucket links

### DIFF
--- a/datasets/hycom-global-drifters.yaml
+++ b/datasets/hycom-global-drifters.yaml
@@ -1,7 +1,7 @@
 Name: HYCOM-OceanTrack Integrated HYCOM Eulerian Fields and Lagrangian Trajectories Dataset
 Description: A combined dataset of simulated ocean sea surface height, near-surface velocities, and particle trajectories from a global 1/25th degree HYbrid Coordinate Ocean Model (HYCOM) 1-year run.
-Documentation: https://github.com/selipot/hycom-global-drifters
-Contact: https://github.com/selipot/hycom-global-drifters/issues
+Documentation: https://github.com/selipot/hycom-oceantrack
+Contact: https://github.com/selipot/hycom-oceantrack/issues
 ManagedBy: Shane Elipot
 UpdateFrequency: Not updated
 Tags:
@@ -15,18 +15,18 @@ Resources:
     Region: us-west-2
     Type: S3 Bucket
     Explore:
-    - '[Browse Bucket](https://registry.opendata.aws/hycom-global-drifters/index.html)'
+    - '[Browse Bucket](https://hycom-global-drifters.s3.amazonaws.com/index.html)'
 DataAtWork:
   Tutorials:
     - Title: HYCOM Eulerian tutorial
-      URL: https://github.com/selipot/hycom-global-drifters/tutorials/
-      NotebookURL: https://github.com/selipot/hycom-global-drifters/tutorials/hycom_eulerian.ipynb
+      URL: https://github.com/selipot/hycom-oceantrack/tutorials/
+      NotebookURL: https://github.com/selipot/hycom-oceantrack/tutorials/hycom_eulerian.ipynb
       AuthorName: Shane Elipot
       AuthorURL: https://selipot.github.io
       Services:
     - Title: HYCOM Lagrangian tutorial
-      URL: https://github.com/selipot/hycom-global-drifters/tutorials/
-      NotebookURL: https://github.com/selipot/hycom-global-drifters/tutorials/hycom_lagrangian.ipynb
+      URL: https://github.com/selipot/hycom-oceantrack/tutorials/
+      NotebookURL: https://github.com/selipot/hycom-oceantrack/tutorials/hycom_lagrangian.ipynb
       AuthorName: Shane Elipot
       AuthorURL: https://selipot.github.io
       Services:  


### PR DESCRIPTION
Corrected the github tutorial links again as well as the bucket URL for exploration