### PR TITLE
2010 & 2020 DHC NMF Confidence Interval URLs

### DIFF
--- a/datasets/census-2010-dhc-nmf.yaml
+++ b/datasets/census-2010-dhc-nmf.yaml
@@ -55,7 +55,7 @@ DataAtWork:
         M., Heiss, C., Johns, R., Kifer, D., Leclerc, P., Machanavajjhala,
         A., Moran, B., Sexton, W., Spence, M., Zhuravlev, P.
     - Title: Computing Confidence Intervals Using the 2010 Census Production Settings Redistricting Data (P.L. 94-171) Demonstration Noisy Measurement File (2023-04-03)
-      URL: https://www2.census.gov/programs-surveys/decennial/2020/program-management/data-product-planning/2010-demonstration-data-products/04-Demonstration_Data_Products_Suite/2023-04-03/Computing-Confidence-Intervals-Using-the-2010-Census-Redistricting-NMF.pdf
+      URL: https://www2.census.gov/programs-surveys/decennial/2020/program-management/data-product-planning/2010-demonstration-data-products/04-Demonstration_Data_Products_Suite/2023-04-03/Computing_Confidence_Intervals_Using_the_2010_Census_Redistricting_NMF.html
       AuthorName:
         Cumings-Menon, R., Hawes, M., and Spence, M. (2023)
         "(Jupyter notebook explaining how to calculate estimates and confidence intervals from the noisy measurement files)"

--- a/datasets/census-2020-dhc-nmf.yaml
+++ b/datasets/census-2020-dhc-nmf.yaml
@@ -63,5 +63,5 @@ DataAtWork:
       URL: https://github.com/uscensusbureau/DAS_2020_DHC_Production_Code/tree/main
       AuthorName: U.S. Census Bureau
     - Title: Computing Confidence Intervals Using the 2010 Census Production Settings Redistricting Data (P.L. 94-171) Demonstration Noisy Measurement File (2023-04-03) (Jupyter notebook explaining how to calculate estimates and confidence intervals from the noisy measurement files)
-      URL: https://www2.census.gov/programs-surveys/decennial/2020/program-management/data-product-planning/2010-demonstration-data-products/04-Demonstration_Data_Products_Suite/2023-04-03/Computing-Confidence-Intervals-Using-the-2010-Census-Redistricting-NMF.pdf.
+      URL: https://www2.census.gov/programs-surveys/decennial/2020/program-management/data-product-planning/2010-demonstration-data-products/04-Demonstration_Data_Products_Suite/2023-04-03/Computing_Confidence_Intervals_Using_the_2010_Census_Redistricting_NMF.html
       AuthorName: Cumings-Menon, R., Hawes, M., and Spence, M. (2023)


### PR DESCRIPTION
Updated Confidence interval hyperlink to reflect proper URL to .html file format on Census FTP. 