### PR TITLE
UniProt releases that are on open-data but not in the registry

### DIFF
--- a/datasets/uniprot.yaml
+++ b/datasets/uniprot.yaml
@@ -18,6 +18,26 @@ Tags:
   - SPARQL
 License: http://creativecommons.org/licenses/by/4.0/ 
 Resources: 
+  - Description: UniProt 2024_02
+    ARN: arn:aws:s3:::aws-open-data-uniprot-rdf/2024-02/
+    Region: eu-west-3
+    Type: S3 Bucket
+  - Description: UniProt 2024_01
+    ARN: arn:aws:s3:::aws-open-data-uniprot-rdf/2024-01/
+    Region: eu-west-3
+    Type: S3 Bucket
+  - Description: UniProt 2023_05
+    ARN: arn:aws:s3:::aws-open-data-uniprot-rdf/2023-05/
+    Region: eu-west-3
+    Type: S3 Bucket
+  - Description: UniProt 2023_04
+    ARN: arn:aws:s3:::aws-open-data-uniprot-rdf/2023-04/
+    Region: eu-west-3
+    Type: S3 Bucket
+  - Description: UniProt 2023_03
+    ARN: arn:aws:s3:::aws-open-data-uniprot-rdf/2023-03/
+    Region: eu-west-3
+    Type: S3 Bucket
   - Description: UniProt 2023_02
     ARN: arn:aws:s3:::aws-open-data-uniprot-rdf/2023-02/
     Region: eu-west-3


### PR DESCRIPTION
Add a number of UniProt releases that should have had pull requests from a script but didn't. My apologies for this.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
