### PR TITLE
Add Element 84 Earth Viewer link to Sentinel2 Explore 

### DIFF
--- a/datasets/sentinel-2.yaml
+++ b/datasets/sentinel-2.yaml
@@ -36,6 +36,7 @@ Resources:
     - '[Earth Search STAC L1C Collection](https://earth-search.aws.element84.com/v1/collections/sentinel-2-l1c)'
     - '[Earth Search STAC Browser L1C Collection](https://radiantearth.github.io/stac-browser/#/external/earth-search.aws.element84.com/v1/collections/sentinel-2-l1c)'
     - '[STAC V1.0.0 endpoint](https://sentinel-s2-l1c-stac.s3.amazonaws.com/)'
+    - '[Earth Viewer by Element 84](https://viewer.aws.element84.com/)'
   - Description: "[S3 Inventory](https://docs.aws.amazon.com/AmazonS3/latest/dev/storage-inventory.html#storage-inventory-contents) files for L1C (ORC and CSV)"
     ARN: arn:aws:s3:::sentinel-inventory/sentinel-s2-l1c
     Region: eu-central-1


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:* modified the sentinel-2.yaml file in my fork to add Element 84's Earth Viewer under Explore


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
