### PR TITLE
Add Herbie as a tool to retrieve ECMWF data

### DIFF
--- a/datasets/ecmwf-forecasts.yaml
+++ b/datasets/ecmwf-forecasts.yaml
@@ -33,6 +33,10 @@ DataAtWork:
       URL: https://github.com/ecmwf/ecmwf-opendata
       AuthorName: ECMWF
       AuthorURL: https://www.ecmwf.int/
+    - Title: "Herbie: A Python package to retrieve NWP data."
+      URL: https://github.com/blaylockbk/Herbie
+      AuthorName: Brian Blaylock
+      AuthorURL: https://github.com/blaylockbk
   Publications:
     - Title: ECMWF makes wide range of data openly available
       URL: https://www.ecmwf.int/en/about/media-centre/news/2022/ecmwf-makes-wide-range-data-openly-available


### PR DESCRIPTION
*Description of changes:*
This changes adds an additional tool, called Herbie, that can be used to retrieve ECMWF forecasts.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
