### PR TITLE
Initial commit - USGS/JAXA/NASA Kaguya/SELENE DTMs

### DIFF
--- a/datasets/jaxa-usgs-nasa-kaguya-tc.yaml
+++ b/datasets/jaxa-usgs-nasa-kaguya-tc.yaml
@@ -1,37 +1,25 @@
 Name: JAXA / USGS / NASA Kaguya/SELENE Terrain Camera Observations
 Description: |
-    The Japan Aerospace EXploration Agency (JAXA) SELenological and ENgineering Explorer (SELENE) mission’s Kaguya spacecraft was launched on September 14, 2007 and science operations around the Moon started October 20, 2007. The primary mission in a circular polar orbit 100-km above the surface lasted from October 20, 2007 until October 31, 2008. An extended mission was then conducted in lower orbits (averaging 50km above the surface) from November 1, 2008 until the SELENE mission ended with Kaguya impacting the Moon on June 10, 2009. These data were collected in monoscopic observing mode. To create these analysis ready data, we have taken the JAXA Data ARchives and Transmission System (DARTS) archived data, map projected the data to equirectangular or polar stereographic (pole centered) based on the center latitude of the observation, and converted to a Cloud Optimized GeoTiff (COG) for online streaming. These data use a priori spacecraft ephemerides (for the nominal mission) and improved, but not controlled spacecraft ephemerides for the extended mission. Therefore, these uncontrolled data are not guaranteed to co-register with other data sets.
+    The Japan Aerospace EXploration Agency (JAXA) SELenological and ENgineering Explorer (SELENE) mission’s Kaguya spacecraft was launched on September 14, 2007 and science operations around the Moon started October 20, 2007. The primary mission in a circular polar orbit 100-km above the surface lasted from October 20, 2007 until October 31, 2008. An extended mission was then conducted in lower orbits (averaging 50km above the surface) from November 1, 2008 until the SELENE mission ended with Kaguya impacting the Moon on June 10, 2009. These data are digital terrain models derived using the NASA Ames Stereo Pipeline (ASP) and the Kaguya stereoscopic data. Digital terrain models (DTMs) in this data set were bundle adjusted and aligned to Lunar Orbiter Laser Altimeter (LOLA) shot data. The sensor model intrinsics used for these data have been re-estimated to reduce inter-DTM horizontal and vertical errors. Data are controlled to LOLA using the ASP pc_align program. Data co-register at orthoimage resolution (11-37 meters per pixel). At image resolution horizontal offsets are measurable. Horizontal precision is measures to be better than 30 meters per pixel on average. Vertical errors are mean centered to zero. An assessment of overlapping DTMs showed vertical precision on the order of 4 meters. Spacecraft jitter and unmodelled lense distortion at the observation edges is believed to be the major contributor to the vertical errors. To create these analysis ready data, we have taken the ASP genreated data, map projected the data to a stereopair centered orthographic projection and converted to a Cloud Optimized GeoTiff (COG) for online streaming. These data use a priori spacecraft ephemerides (for the nominal mission) and improved, but not controlled spacecraft ephemerides for the extended mission. These data co-register with other LOLA controlled data to the aforementioned horizontal and vertical accuracies.
 Documentation: https://stac.astrogeology.usgs.gov/docs/data/moon/kaguyatc/
 Contact: https://answers.usgs.gov/
 ManagedBy: "[NASA](https://www.nasa.gov)"
-UpdateFrequency: The Kaguya/SELENE mission has completed. No updates to this dataset are planned.
+UpdateFrequency: The Kaguya/SELENE mission has completed. No regular updates to this dataset are planned.
 Tags:
   - aws-pds
   - planetary
-  - satellite imagery
+  - elevation
   - stac
   - cog
 License: "[CC0 1.0](https://creativecommons.org/publicdomain/zero/1.0/)"
-Citation: https://doi.org/10.5066/P9SH5YNV
+Citation: https://doi.org/10.5066/P13D7VMG
 Resources:
-  - Description: Scenes and metadata for monoscopic observing mode
-    ARN: arn:aws:s3:::astrogeo-ard/moon/kaguya/terrain_camera/monoscopic/uncontrolled/
+  - Description: Digital terrain models, orthoimages, shaded reliefs, and quality assurance documents
+    ARN: arn:aws:s3:::astrogeo-ard/moon/kaguya/terrain_camera/usgs_dtms/
     Region: us-west-2
     Type: S3 Bucket
     Explore:
-      - '[STAC Catalog](https://stac.astrogeology.usgs.gov/browser-dev/#/api/collections/kaguya_terrain_camera_monoscopic_uncontrolled_observations)'
-  - Description: Scenes and metadata for stereoscopic observing mode
-    ARN: arn:aws:s3:::astrogeo-ard/moon/kaguya/terrain_camera/stereoscopic/uncontrolled/
-    Region: us-west-2
-    Type: S3 Bucket
-    Explore:
-      - '[STAC Catalog](https://stac.astrogeology.usgs.gov/browser-dev/#/api/collections/kaguya_terrain_camera_stereoscopic_uncontrolled_observations)'
-  - Description: Scenes and metadata for spectral profiler (spsupport) observing mode
-    ARN: arn:aws:s3:::astrogeo-ard/moon/kaguya/terrain_camera/spsupport/uncontrolled/
-    Region: us-west-2
-    Type: S3 Bucket
-    Explore:
-      - '[STAC Catalog](https://stac.astrogeology.usgs.gov/browser-dev/#/api/collections/kaguya_terrain_camera_spsupport_uncontrolled_observations)'
+      - '[STAC Catalog](https://stac.astrogeology.usgs.gov/browser-dev/#/api/collections/kaguya_terrain_camera_usgs_dtms)'
 DataAtWork:
   Tutorials:
     - Title: "Discovering and Downloading Data via the Command Line"


### PR DESCRIPTION
*Issue #, if available:*
N/A
*Description of changes:*
Adds USGS created Kaguya/SELENE DTMs (n>134,000) covering ±70˚ and wrapping the entire globe.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
