### PR TITLE
improve rendering of s1-orbits description

### DIFF
--- a/datasets/s1-orbits.yaml
+++ b/datasets/s1-orbits.yaml
@@ -3,11 +3,11 @@ Description: >
   Sentinel-1 Precise Orbit Determination (POD) products contain auxiliary data on satellite position and velocity for the European Space Agency's (ESA) Sentinel-1 mission. Sentinel-1 is a C-band Synthetic Aperture Radar (SAR) satellite constellation first launched in 2014 as part of the European Union's Copernicus Earth Observation programme. POD products are a necessary auxiliary input for nearly all Sentinel-1 data processing workflows.
   <br/><br/>
   This dataset is a mirror of the [Sentinel-1 Orbits](https://documentation.dataspace.copernicus.eu/Data/ComplementaryData/Additional.html#sentinel-1-orbits) dataset hosted in the Copernicus Data Space Ecosystem (CDSE). New files are added within 20 minutes of their publication to CDSE. This dataset includes two types of POD files: RESORB and POEORB.
+  <ul>
+  <li>RESORB POD files are restituted orbit files generated within 180 minutes from sensing time and published multiple times per day, with accuracy requirement of 10 cm in 2D RMS, but typically below 5 cm. RESORB products from the last 90 days are included in this dataset.</li>
   <br/>
-  - RESORB POD files are restituted orbit files generated within 180 minutes from sensing time and published multiple times per day, with accuracy requirement of 10 cm in 2D RMS, but typically below 5 cm. RESORB products from the last 90 days are included in this dataset.
-  <br/>
-  - POEORB POD files are precise orbit files generated with a timeliness of 20 days from sensing time and published once per day, with accuracy requirement of 5 cm in 3D RMS, but typically below 1 cm. Once available, these files supersede the RESORB products, as they contain the same data with better accuracy. POEORB products are available from the entire length of the Sentinel-1 mission.
-  <br/><br/>
+  <li>POEORB POD files are precise orbit files generated with a timeliness of 20 days from sensing time and published once per day, with accuracy requirement of 5 cm in 3D RMS, but typically below 1 cm. Once available, these files supersede the RESORB products, as they contain the same data with better accuracy. POEORB products are available from the entire length of the Sentinel-1 mission.</li>
+  </ul>
   For more information on the orbit products, see the [POD Sentinel-1 Products Specification](https://sentiwiki.copernicus.eu/web/s1-processing#S1Processing-PODSentinel-1ProductsSpecificationS1-Processing-POD-Sentinel-1-Products-Specification).
 Documentation: https://s1-orbits.s3.us-west-2.amazonaws.com/README.html
 Contact: https://asf.alaska.edu/asf/contact-us/


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Adding html tags in https://github.com/awslabs/open-data-registry/pull/2336 made the markdown list stop being rendered as an html list; this should make the bulleted list render again:

![Screenshot from 2024-08-14 17-31-47](https://github.com/user-attachments/assets/90ebf6e3-02c5-4120-936a-97ff4a4e98c6)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
