### PR TITLE
Updated link to Sentinel-2 water hyacinth project

### DIFF
--- a/datasets/sentinel-2-l2a-cogs.yaml
+++ b/datasets/sentinel-2-l2a-cogs.yaml
@@ -87,6 +87,12 @@ DataAtWork:
       AuthorName: Xiong Zhou, Anirudh Viswanathan, Erran Li, Trenton Lipscomb, and Xingjian Shi 
       Services:
       - SageMaker
+    - Title: Using Sentinel-2 Data from the AWS Open Data Project to measure water hyacinth growth
+      URL: https://github.com/aws-samples/monitor-water-hyacinth-invasion
+      NotebookURL: https://github.com/aws-samples/monitor-water-hyacinth-invasion/blob/main/Harties.ipynb
+      AuthorName: Louise Liddell
+      Services:
+        - SageMaker Studio Lab
   Publications:
     - Title: STAC and Sentinel-2 COGs (ESIP Summer Meeting 2020)
       URL: https://docs.google.com/presentation/d/14NsKFZ3UF2Swwx_9L7sPMX9ccFUK1ruQyZXWK9Cz4L4/edit?usp=sharing

--- a/datasets/sentinel-2.yaml
+++ b/datasets/sentinel-2.yaml
@@ -115,12 +115,6 @@ DataAtWork:
       Services:
         - SageMaker
         - Lambda
-    - Title: Using Sentinel-2 Data from the AWS Open Data Project to measure water hyacinth growth
-      URL: https://gitlab.aws.dev/ltl/aws-sentinel2-smsl-water-hyacinth
-      NotebookURL: https://gitlab.aws.dev/ltl/aws-sentinel2-smsl-water-hyacinth/-/blob/main/Harties.ipynb
-      AuthorName: Louise Liddell
-      Services:
-        - SageMaker Studio Lab
   Tools & Applications:
     - Title: Sentinel Hub WMS/WMTS/WCS Service
       URL: http://www.sentinel-hub.com/apps/wms


### PR DESCRIPTION
Updated the link to the Hartbeespoort Water Hyacinth project to demonstrate usage of the Sentinel-2 COGs dataset.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
