### PR TITLE
Fix AODN documentation URL

### DIFF
--- a/datasets/aodn_model_sea_level_anomaly_gridded_realtime.yaml
+++ b/datasets/aodn_model_sea_level_anomaly_gridded_realtime.yaml
@@ -26,7 +26,7 @@ Description: "Gridded (adjusted) sea level anomaly (GSLA), gridded sea level (GS
   \ analysis date (-21 to 4 days). For both NRT and DM, altimeter data is weighted\
   \ by the difference between the analysis date of the map and the time of each altimeter\
   \ observation.\n\nReferences: http://imos.aodn.org.au/oceancurrent"
-Documentation: https://catalogue-imos.org.au/geonetwork/srv/eng/catalog.search#/metadata/0c9eb39c-9cbe-4c6a-8a10-5867087e703a
+Documentation: https://catalogue-imos.aodn.org.au/geonetwork/srv/eng/catalog.search#/metadata/0c9eb39c-9cbe-4c6a-8a10-5867087e703a
 License: http://creativecommons.org/licenses/by/4.0/
 ManagedBy: AODN
 Name: OceanCurrent - Gridded sea level anomaly - Near real time

--- a/datasets/aodn_mooring_ctd_delayed_qc.yaml
+++ b/datasets/aodn_mooring_ctd_delayed_qc.yaml
@@ -25,7 +25,7 @@ Description: This collection includes conductivity-temperature-depth (CTD) profi
   and variability in the global ocean are affecting the ecosystems of Australia's
   coastal seas. The stations are operated by the Australian National Moorings Network
   (ANMN), a facility of the Integrated Marine Observing System (IMOS).
-Documentation: https://catalogue-imos.org.au/geonetwork/srv/eng/catalog.search#/metadata/7b901002-b1dc-46c3-89f2-b4951cedca48
+Documentation: https://catalogue-imos.aodn.org.au/geonetwork/srv/eng/catalog.search#/metadata/7b901002-b1dc-46c3-89f2-b4951cedca48
 License: http://creativecommons.org/licenses/by/4.0/
 ManagedBy: AODN
 Name: National Mooring Network - CTD profiles

--- a/datasets/aodn_mooring_hourly_timeseries_delayed_qc.yaml
+++ b/datasets/aodn_mooring_hourly_timeseries_delayed_qc.yaml
@@ -33,7 +33,7 @@ Description: "Integrated Marine Observing System (IMOS) have moorings across bot
   \ made using a range of temperature loggers, conductivity-temperature-depth (CTD)\
   \ instruments, water-quality monitors (WQM), acoustic Doppler current profilers\
   \ (ADCPs), and single-point current meters."
-Documentation: https://catalogue-imos.org.au/geonetwork/srv/eng/catalog.search#/metadata/efd8201c-1eca-412e-9ad2-0534e96cea14
+Documentation: https://catalogue-imos.aodn.org.au/geonetwork/srv/eng/catalog.search#/metadata/efd8201c-1eca-412e-9ad2-0534e96cea14
 License: http://creativecommons.org/licenses/by/4.0/
 ManagedBy: AODN
 Name: Moorings - Hourly time-series product

--- a/datasets/aodn_mooring_temperature_logger_delayed_qc.yaml
+++ b/datasets/aodn_mooring_temperature_logger_delayed_qc.yaml
@@ -27,7 +27,7 @@ Description: The Australian National Mooring Network (ANMN) Facility is a series
   (CTD) instruments, and temperature sensors on acoustic Doppler current profilers
   (ADCPs). We are also producing a gridded product of temperature time-series profiles
   based on these data. These will be available in a separate collection.
-Documentation: https://catalogue-imos.org.au/geonetwork/srv/eng/catalog.search#/metadata/7e13b5f3-4a70-4e31-9e95-335efa491c5c
+Documentation: https://catalogue-imos.aodn.org.au/geonetwork/srv/eng/catalog.search#/metadata/7e13b5f3-4a70-4e31-9e95-335efa491c5c
 License: http://creativecommons.org/licenses/by/4.0/
 ManagedBy: AODN
 Name: National Mooring Network - Temperature and salinity time-series

--- a/datasets/aodn_radar_turquoisecoast_velocity_hourly_average_delayed_qc.yaml
+++ b/datasets/aodn_radar_turquoisecoast_velocity_hourly_average_delayed_qc.yaml
@@ -44,7 +44,7 @@ Description: "The Turquoise Coast (TURQ) HF ocean radar system covers the area o
   \ Rottnest Shelf (ROT) WERA HF ocean radar system on its south side.  Together,\
   \ the TURQ and ROT systems provide continuous monitoring of the shelf from Fremantle\
   \ to Jurien Bay."
-Documentation: https://catalogue-imos.org.au/geonetwork/srv/eng/catalog.search#/metadata/055342fc-f970-4be7-a764-8903220d42fb
+Documentation: https://catalogue-imos.aodn.org.au/geonetwork/srv/eng/catalog.search#/metadata/055342fc-f970-4be7-a764-8903220d42fb
 License: http://creativecommons.org/licenses/by/4.0/
 ManagedBy: AODN
 Name: Ocean Radar - Turquoise coast site -Sea water velocity - Delayed mode

--- a/datasets/aodn_receiver_animal_acoustic_tagging_delayed_qc.yaml
+++ b/datasets/aodn_receiver_animal_acoustic_tagging_delayed_qc.yaml
@@ -33,7 +33,7 @@ Description: "Since 2007, the Integrated Marine Observing System\u2019s Animal T
   \ is updated on a six-monthly basis.\n\nNote - There is a static snapshot of the\
   \ database (up until 2017) (http://dx.doi.org/10.4225/69/5979810a7dd6f), and this\
   \ has been documented in a Scientific Data Publication (Hoenner et al. 2018)."
-Documentation: https://catalogue-imos.org.au/geonetwork/srv/eng/catalog.search#/metadata/541d4f15-122a-443d-ab4e-2b5feb08d6a0
+Documentation: https://catalogue-imos.aodn.org.au/geonetwork/srv/eng/catalog.search#/metadata/541d4f15-122a-443d-ab4e-2b5feb08d6a0
 License: http://creativecommons.org/licenses/by/4.0/
 ManagedBy: AODN
 Name: Animal Tracking - Acoustic Telemetry - Quality controlled detections

--- a/datasets/aodn_satellite_ghrsst_l3s_1day_daynighttime_single_sensor_australia.yaml
+++ b/datasets/aodn_satellite_ghrsst_l3s_1day_daynighttime_single_sensor_australia.yaml
@@ -28,7 +28,7 @@ Description: "This is a single-sensor multi-satellite  SSTfnd product for a sing
   \ Refer to the IMOS SST products web page at http://imos.org.au/sstproducts.html\
   \ and Beggs et al. (2013) at http://imos.org.au/sstdata_references.html for further\
   \ information."
-Documentation: https://catalogue-imos.org.au/geonetwork/srv/eng/catalog.search#/metadata/a136eee7-a990-4c06-a4f6-915657a2464e
+Documentation: https://catalogue-imos.aodn.org.au/geonetwork/srv/eng/catalog.search#/metadata/a136eee7-a990-4c06-a4f6-915657a2464e
 License: http://creativecommons.org/licenses/by/4.0/
 ManagedBy: AODN
 Name: Satellite - Sea surface temperature - Level 3 - Single sensor - 1 day - Day

--- a/datasets/aodn_slocum_glider_delayed_qc.yaml
+++ b/datasets/aodn_slocum_glider_delayed_qc.yaml
@@ -43,7 +43,7 @@ Description: The Australian National Facility for Ocean Gliders (ANFOG), with IM
   Australian Current (EAC). The study of these currents is critical for understanding
   the north-south transport of freshwater, heat and biogeochemical properties. The
   currents exert a large influence on coastal ecosystems, shipping lanes and fisheries.
-Documentation: https://catalogue-imos.org.au/geonetwork/srv/eng/catalog.search#/metadata/c317b0fe-02e8-4ff9-96c9-563fd58e82ac
+Documentation: https://catalogue-imos.aodn.org.au/geonetwork/srv/eng/catalog.search#/metadata/c317b0fe-02e8-4ff9-96c9-563fd58e82ac
 License: http://creativecommons.org/licenses/by/4.0/
 ManagedBy: AODN
 Name: Ocean Gliders - Delayed mode

--- a/datasets/aodn_vessel_co2_delayed_qc.yaml
+++ b/datasets/aodn_vessel_co2_delayed_qc.yaml
@@ -29,7 +29,7 @@ Description: "The IMOS Ship of Opportunity Underway CO2 Measurements group is a 
   \ Antarctica. The New Zealand National Institute of Water & Atmospheric Research\
   \ Ltd. (NIWA) has supported the setup of underway CO2 measurements on the RV Tangaroa.\
   \ The Tangaroa covers oceans adjacent to New Zealand."
-Documentation: https://catalogue-imos.org.au/geonetwork/srv/eng/catalog.search#/metadata/63db5801-cc19-40ef-83b3-85ccba884cf7
+Documentation: https://catalogue-imos.aodn.org.au/geonetwork/srv/eng/catalog.search#/metadata/63db5801-cc19-40ef-83b3-85ccba884cf7
 License: http://creativecommons.org/licenses/by/4.0/
 ManagedBy: AODN
 Name: Ships of Opportunity - Biogeochemical sensors - Delayed mode

--- a/datasets/aodn_vessel_fishsoop_realtime_qc.yaml
+++ b/datasets/aodn_vessel_fishsoop_realtime_qc.yaml
@@ -35,7 +35,7 @@ Description: "FishSOOP (Fisheries Ships of Opportunities) is an IMOS Sub-Facilit
   \ shark gillnets, otter board trawlers, lobster pots, fish traps, prawn trawlers,\
   \ squid jigs, and danish seines. We also had a pre-trial test with one boat the\
   \ year prior, with the sensor installed on a trawler."
-Documentation: https://catalogue-imos.org.au/geonetwork/srv/eng/catalog.search#/metadata/bdb84466-dc53-49ad-a60f-83d9fa0baed5
+Documentation: https://catalogue-imos.aodn.org.au/geonetwork/srv/eng/catalog.search#/metadata/bdb84466-dc53-49ad-a60f-83d9fa0baed5
 License: http://creativecommons.org/licenses/by/4.0/
 ManagedBy: AODN
 Name: Ships of Opportunity - Fisheries vessels - Real time

--- a/datasets/aodn_vessel_sst_delayed_qc.yaml
+++ b/datasets/aodn_vessel_sst_delayed_qc.yaml
@@ -29,7 +29,7 @@ Description: "The IMOS Ship of Opportunity Underway CO2 Measurements group is a 
   \ Antarctica. The New Zealand National Institute of Water & Atmospheric Research\
   \ Ltd. (NIWA) has supported the setup of underway CO2 measurements on the RV Tangaroa.\
   \ The Tangaroa covers oceans adjacent to New Zealand."
-Documentation: https://catalogue-imos.org.au/geonetwork/srv/eng/catalog.search#/metadata/3999f117-b50e-4b5e-92e9-82ed04a736d5
+Documentation: https://catalogue-imos.aodn.org.au/geonetwork/srv/eng/catalog.search#/metadata/3999f117-b50e-4b5e-92e9-82ed04a736d5
 License: http://creativecommons.org/licenses/by/4.0/
 ManagedBy: AODN
 Name: Ships of Opportunity - Sea surface temperature - 1-minute average data products

--- a/datasets/aodn_vessel_trv_realtime_qc.yaml
+++ b/datasets/aodn_vessel_trv_realtime_qc.yaml
@@ -41,7 +41,7 @@ Description: "The research vessels (RV Cape Ferguson and RV Solander) of the Aus
   \ used in real time sea surface temperature analyses and climate data records. Access\
   \ to the additional data collected by the AIMS research vessels, is provided on\
   \ the AIMS data repository here: https://apps.aims.gov.au/metadata/view/8af21108-c535-43bf-8dab-c1f45a26088c."
-Documentation: https://catalogue-imos.org.au/geonetwork/srv/eng/catalog.search#/metadata/8af21108-c535-43bf-8dab-c1f45a26088c
+Documentation: https://catalogue-imos.aodn.org.au/geonetwork/srv/eng/catalog.search#/metadata/8af21108-c535-43bf-8dab-c1f45a26088c
 License: http://creativecommons.org/licenses/by/4.0/
 ManagedBy: AODN
 Name: Ships of Opportunity - Tropical research vessels - Real time

--- a/datasets/aodn_vessel_xbt_realtime_nonqc.yaml
+++ b/datasets/aodn_vessel_xbt_realtime_nonqc.yaml
@@ -26,7 +26,7 @@ Description: XBT real-time data is available through the IMOS portal. Data is ac
   to the GTSPP global data acquisition centre in Washington DC where it is made freely
   available to all. This SOOP dataset covers waters around Australia and across to
   New Zealand.
-Documentation: https://catalogue-imos.org.au/geonetwork/srv/eng/catalog.search#/metadata/35234913-aa3c-48ec-b9a4-77f822f66ef8
+Documentation: https://catalogue-imos.aodn.org.au/geonetwork/srv/eng/catalog.search#/metadata/35234913-aa3c-48ec-b9a4-77f822f66ef8
 License: http://creativecommons.org/licenses/by/4.0/
 ManagedBy: AODN
 Name: Ships of Opportunity - Expendable bathythermographs - Real time

--- a/datasets/aodn_wave_buoy_realtime_nonqc.yaml
+++ b/datasets/aodn_wave_buoy_realtime_nonqc.yaml
@@ -46,7 +46,7 @@ Description: "Buoys provide integral wave parameters. Buoy data from the followi
   \ 2024).\n\nIMOS (some), DPE, UWA, Deakin, Flinders University + SARDI - The data\
   \ is updated every hour, at 40 minutes past the hour.\n\nPilbara Ports Authority\
   \ - The data is uploaded every hour, at 30 minutes past the hour."
-Documentation: https://catalogue-imos.org.au/geonetwork/srv/eng/catalog.search#/metadata/b299cdcd-3dee-48aa-abdd-e0fcdbb9cadc
+Documentation: https://catalogue-imos.aodn.org.au/geonetwork/srv/eng/catalog.search#/metadata/b299cdcd-3dee-48aa-abdd-e0fcdbb9cadc
 License: http://creativecommons.org/licenses/by/4.0/
 ManagedBy: AODN
 Name: Wave buoys observations - Real time


### PR DESCRIPTION
'.aodn' was missing in all documentation URLs