### PR TITLE
feat: add publications

### DIFF
--- a/datasets/hycom-global-drifters.yaml
+++ b/datasets/hycom-global-drifters.yaml
@@ -46,6 +46,12 @@ DataAtWork:
       AuthorName: Shane Elipot
       AuthorURL: https://selipot.github.io
   Publications: 
+    - Title: An integrated dataset of near-surface Eulerian fields and Lagrangian trajectories from an ocean model
+      URL: https://doi.org/10.1038/s41597-024-03813-z
+      AuthorName: Shane Elipot
+    - Title: HYCOM-OceanTrack: HYCOM-OceanTrack: Integrated HYCOM Eulerian Fields and Lagrangian Trajectories Dataset (v1.0)
+      URL: https://doi.org/10.5281/zenodo.12796468
+      AuthorName: Shane Elipot
     - Title: Near-Surface Oceanic Kinetic Energy Distributions From Drifter Observations and Numerical Models
       URL: https://dx.doi.org/10.1029/2022JC018551
       AuthorName: Brian K. Arbic

--- a/datasets/hycom-global-drifters.yaml
+++ b/datasets/hycom-global-drifters.yaml
@@ -49,7 +49,7 @@ DataAtWork:
     - Title: An integrated dataset of near-surface Eulerian fields and Lagrangian trajectories from an ocean model
       URL: https://doi.org/10.1038/s41597-024-03813-z
       AuthorName: Shane Elipot
-    - Title: HYCOM-OceanTrack: HYCOM-OceanTrack: Integrated HYCOM Eulerian Fields and Lagrangian Trajectories Dataset (v1.0)
+    - Title: "HYCOM-OceanTrack: HYCOM-OceanTrack: Integrated HYCOM Eulerian Fields and Lagrangian Trajectories Dataset (v1.0)"
       URL: https://doi.org/10.5281/zenodo.12796468
       AuthorName: Shane Elipot
     - Title: Near-Surface Oceanic Kinetic Energy Distributions From Drifter Observations and Numerical Models


### PR DESCRIPTION
*Added publications for the dataset:*

I have added the following zenodo link/archive:

Elipot, S., Faigle, E., Arbic, B. K., & Shriver, J. F. (2024). HYCOM-OceanTrack: Integrated HYCOM Eulerian Fields and Lagrangian Trajectories Dataset (v1.0) [Data set]. Zenodo. https://doi.org/10.5281/zenodo.12796468

and the following data descriptor paper just published:

Elipot, S., Faigle, E., Arbic, B.K. et al. An integrated dataset of near-surface Eulerian fields and Lagrangian trajectories from an ocean model. Sci Data 11, 943 (2024). https://doi.org/10.1038/s41597-024-03813-z

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
