### PR TITLE
Update software-heritage.yaml : make explicit scope of license.

### DIFF
--- a/datasets/software-heritage.yaml
+++ b/datasets/software-heritage.yaml
@@ -13,6 +13,7 @@ Description: |
     Debian), and language-specific package managers (e.g., PyPI). Crawling
     information is also included, providing timestamps about when and where all
     archived source code artifacts have been observed in the wild.
+    Author and committer information is anonymized.
 Documentation: https://docs.softwareheritage.org/devel/swh-dataset/graph/athena.html
 Contact: aws@softwareheritage.org
 ManagedBy: Software Heritage
@@ -24,8 +25,10 @@ Tags:
   - free software
   - digital preservation
 License: |
-    Creative Commons Attribution 4.0 International.
-
+    The term "Software Heritage Graph Dataset" designates the internal structure of the Software Heritage archive, and explicitly excludes the file contents.
+    The "Software Heritage Graph Dataset" is distributed under the Creative Commons Attribution 4.0 International license.
+    For terms of use of all other contents found in the S3 buckets, contact datasets@softwareheritage.org
+    
     By accessing the dataset, you agree with the Software Heritage [Ethical
     Charter for using the archive
     data](https://www.softwareheritage.org/legal/users-ethical-charter/) and
@@ -41,6 +44,6 @@ Resources:
     Region: us-east-1
     Type: S3 Bucket
 DataAtWork:
-  Tutorials:
-  Tools & Applications:
+  Tutorials: https://docs.softwareheritage.org/devel/swh-dataset/graph/index.html
+  Tools & Applications: https://docs.softwareheritage.org/devel/swh-graph/index.html
   Publications:


### PR DESCRIPTION
Added wording to make explicit that Creative Commons applies to the graph dataset only. Added also links to documentation, tutorials and tools.

*Issue #2374 *

*Description of changes:*
Clarify scope of Creative Commons licence, and add link to tools and tutorial.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
