### PR TITLE
Update noaa-goes.yaml

### DIFF
--- a/datasets/noaa-goes.yaml
+++ b/datasets/noaa-goes.yaml
@@ -2,6 +2,9 @@ Name: "NOAA Geostationary Operational Environmental Satellites (GOES) 16, 17 & 1
 Description: |
   <br/>
   <br/> 
+  **DATA FEED ISSUES - Due to major damage to critical infrastructure in the Asheville, NC area from Hurricane Helene, our GOES data feeds to the cloud have been impacted. We are working with local authorities and service providers in hopes that we can restore these feeds ASAP. Note that major celluar and network (fiber) infrastructure have been damaged and this may take time to adress. Thank you for your continued support.** 
+  <br/>
+  <br/> 
   NOTICE: As of January 10th 2023, GOES-18 assumed the GOES-West position and all data files are deemed both operational and provisional, so no ‘preliminary, non-operational’ caveat is needed. GOES-17 is now offline, shifted approximately 105 degree West, where it will be in on-orbit storage. GOES-17 data will no longer flow into the GOES-17 bucket. Operational GOES-West products can be found in the GOES-18 bucket. 
   <br/>
   <br/> 


### PR DESCRIPTION
GOES Feeds to cloud are down due to Hurricane Helene damage to critical infrastructure.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
