### PR TITLE
Update GEOS-Chem Input Data and GEOS-Chem Nested Input Data registries to avoid errors

### DIFF
--- a/datasets/geoschem-input-data.yaml
+++ b/datasets/geoschem-input-data.yaml
@@ -3,7 +3,7 @@ Description: Input data for the GEOS-Chem Chemical Transport Model, includes NAS
 Documentation: https://geos-chem.readthedocs.io/en/latest/geos-chem-shared-docs/supplemental-guides/geos-chem-input-data-on-aws.html
 Contact: https://geoschem.github.io/support-team.html
 UpdateFrequency: New meteorological and emission data will be added when available.
-ManagedBy: "[Washington University in St. Louis](https://wustl.edu) and [Harvard University](https://www.harvard.edu/)"
+ManagedBy: "[GEOS-Chem Support Team](https://geoschem.github.io/support-team.html)"
 Collabs:
   ASDI:
     Tags:
@@ -25,7 +25,7 @@ Resources:
     Region: us-east-1
     Type: S3 Bucket
     Explore:
-    - '[Browse Bucket](https://s3.amazonaws.com/geos-chem/index.html)'
+    - '[Browse Bucket](https://geos-chem.s3.amazonaws.com/index.html)'
 DataAtWork:
   Tutorials:
     - Title: Getting started with GEOS-Chem Input Data

--- a/datasets/geoschem-nested-input-data.yaml
+++ b/datasets/geoschem-nested-input-data.yaml
@@ -3,7 +3,7 @@ Description: Input data for nested-grid simulations using the GEOS-Chem Chemical
 Documentation: https://geos-chem.readthedocs.io
 Contact: http://geos-chem.org/support-team
 UpdateFrequency: New meteorological and emission data will be added when available.
-ManagedBy: "[Harvard University](https://www.harvard.edu/) and [Washington University in St. Louis](https://wustl.edu)"
+ManagedBy: "[GEOS-Chem Support Team](https://geoschem.github.io/support-team.html)"
 Collabs:
   ASDI:
     Tags:


### PR DESCRIPTION
*Issue #, if available:*

The ManagedBy entry seems to only access a single Markdown entity (specified in this issue #983 ). We updated both registries to avoid wrong format.

*Description of changes:*

1. Updated the ManagedBy entries in both GEOS-Chem Input Data and GEOS-Chem Nested Input Data

2. Updated the subdomain of AWS explorer link to find the valid page. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
