### PR TITLE
Update typos in spartan-cloud.yaml

### DIFF
--- a/datasets/spartan-cloud.yaml
+++ b/datasets/spartan-cloud.yaml
@@ -3,7 +3,7 @@ Description: SPARTAN (Surface PARTiculate mAtter Network) measures and provides 
 Documentation: https://www.spartan-network.org/data
 Contact: SPARTAN.PM25@gmail.com
 UpdateFrequency: New measurement or estimation products will be added when available, usually multiple times a month.
-ManagedBy: "The [Atmospheric Composition Analysis Group](https://sites.wustl.edu/acag/) at [Washington University in St. Louis](https://wustl.edu)"
+ManagedBy: 'The [Atmospheric Composition Analysis Group](https://sites.wustl.edu/acag/) at [Washington University in St. Louis](https://wustl.edu)'
 Collabs:
   ASDI:
     Tags:

--- a/datasets/spartan-cloud.yaml
+++ b/datasets/spartan-cloud.yaml
@@ -3,7 +3,7 @@ Description: SPARTAN (Surface PARTiculate mAtter Network) measures and provides 
 Documentation: https://www.spartan-network.org/data
 Contact: SPARTAN.PM25@gmail.com
 UpdateFrequency: New measurement or estimation products will be added when available, usually multiple times a month.
-ManagedBy: 'The [Atmospheric Composition Analysis Group](https://sites.wustl.edu/acag/) at [Washington University in St. Louis](https://wustl.edu)'
+ManagedBy: 'The [Atmospheric Composition Analysis Group](https://sites.wustl.edu/acag/)'
 Collabs:
   ASDI:
     Tags:


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
I noticed typos on https://registry.opendata.aws/spartan-cloud/. Specifically, the line "See all datasets managed by Atmospheric Composition Analysis Group ](https://sites.wustl.edu/acag/) at [Washington University in St. Louis."

I replaced ' " ' with single comma and suppose this fix the typo. But let me know if it doesn't. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
