### PR TITLE
Update surface-pm2-5-v6gl02.yaml

### DIFF
--- a/datasets/surface-pm2-5-v6gl02.yaml
+++ b/datasets/surface-pm2-5-v6gl02.yaml
@@ -17,7 +17,7 @@ Resources:
     Region: us-west-2
     Type: S3 Bucket
     Explore:
-    - '[Browse Bucket](https://v6.pm25.global.s3.amazonaws.com/index.html)'
+    - '[Browse Bucket](https://s3.us-west-2.amazonaws.com/v6.pm25.global/index.html)'
 DataAtWork:
   Tutorials:
     - Title: Importing and Plotting the V6.GL.02.02 dataset into Matlab


### PR DESCRIPTION
Change the Expolre Bucket wed address, the old one was not working for some reason.  New address: "https://s3.us-west-2.amazonaws.com/v6.pm25.global/index.html"

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
