### PR TITLE
Suggestion to add 'geography' as a new tag

### DIFF
--- a/tags.yaml
+++ b/tags.yaml
@@ -165,6 +165,7 @@
 - genomic
 - genotyping
 - geochemistry
+- geography
 - geology
 - geopackage
 - geophysics


### PR DESCRIPTION
*Description of changes:*

I see an existing tag for geology.  I feel it would be appropriate to add a similar tag of 'geography' to use for datasets that have a geographic component of some sort.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
