### PR TITLE
Create satellogic-earthview.yaml

### DIFF
--- a/datasets/satellogic-earthview.yaml
+++ b/datasets/satellogic-earthview.yaml
@@ -8,12 +8,9 @@ Tags:
   - aws-pds
   - satellite imagery
   - earth observation
-  - remote sensing  
   - image processing
   - geospatial
-  - high-resolution
-  - top-of-atmosphere reflectance
-  - spectral bands
+  - computer vision
   - stac
   - cog  
 License: "[CC BY 4.0](https://creativecommons.org/licenses/by/4.0/deed.en)"

--- a/datasets/satellogic-earthview.yaml
+++ b/datasets/satellogic-earthview.yaml
@@ -1,0 +1,31 @@
+Name: Satellogic EarthView dataset
+Description: Satellogic EarthView dataset includes high-resolution satellite images captured over all continents. The dataset is organized in Hive partition format and hosted by AWS. The dataset can be accessed via STAC browser or aws cli. Each item of the dataset corresponds to a specific region and date, with some of the regions revisited for additional data. The dataset provides Top-of-Atmosphere (TOA) reflectance values across four spectral bands (Red, Green, Blue, Near-Infrared) at a Ground Sample Distance (GSD) of 1 meter, accompanied by comprehensive metadata such as off-nadir angles, sun elevation, and other pertinent details. Users should note that due to an artifact in region delineation, a small number of regions present overlaps.
+Documentation: https://satellogic-earthview.s3.us-west-2.amazonaws.com/index.html
+Contact: https://www.satellogic.com/
+ManagedBy: "[Satellogic](https://www.satellogic.com)"
+UpdateFrequency: New data will be made available periodically, with annual updates expected in the future covering the same or other new regions.
+Tags:
+  - aws-pds
+  - satellite imagery
+  - earth observation
+  - remote sensing  
+  - image processing
+  - geospatial
+  - high-resolution
+  - top-of-atmosphere reflectance
+  - spectral bands
+  - stac
+  - cog  
+License: "[CC BY 4.0](https://creativecommons.org/licenses/by/4.0/deed.en)"
+Resources:
+  - Description: Satellogic data includes TOA RGBN COG, VISUAL RGB COG files data and metadata
+    ARN: arn:aws:s3:::satellogic-earthview
+    Region: us-west-2
+    Type: S3 Bucket
+    RequesterPays: False
+    Explore:
+    - '[STAC Catalog](https://satellogic-earthview.s3.us-west-2.amazonaws.com/stac/catalog.json)'
+    - '[STAC Browser](https://radiantearth.github.io/stac-browser/#/external/satellogic-earthview.s3.us-west-2.amazonaws.com/stac/catalog.json)'
+Publications:
+  - Title: EarthView: A Large Scale Remote Sensing Dataset for Self-Supervision
+    AuthorName: Velázquez, Diego and Rodríguez, Pau and Alonso, Sergio and Gonfaus, Josep M. and González, Jordi and, Richarte, Gerardo and Marín, Javier and Bengio, Yoshua and Lacoste, Alexandre

--- a/datasets/satellogic-earthview.yaml
+++ b/datasets/satellogic-earthview.yaml
@@ -26,6 +26,8 @@ Resources:
     Explore:
     - '[STAC Catalog](https://satellogic-earthview.s3.us-west-2.amazonaws.com/stac/catalog.json)'
     - '[STAC Browser](https://radiantearth.github.io/stac-browser/#/external/satellogic-earthview.s3.us-west-2.amazonaws.com/stac/catalog.json)'
-Publications:
-  - Title: EarthView: A Large Scale Remote Sensing Dataset for Self-Supervision
-    AuthorName: Velázquez, Diego and Rodríguez, Pau and Alonso, Sergio and Gonfaus, Josep M. and González, Jordi and, Richarte, Gerardo and Marín, Javier and Bengio, Yoshua and Lacoste, Alexandre
+DataAtWork:
+  Publications:
+    - Title: EarthView: A Large Scale Remote Sensing Dataset for Self-Supervision
+      URL: https://satellogic-earthview.s3.us-west-2.amazonaws.com/index.html
+      AuthorName: Velázquez, Diego and Rodríguez, Pau and Alonso, Sergio and Gonfaus, Josep M. and González, Jordi and, Richarte, Gerardo and Marín, Javier and Bengio, Yoshua and Lacoste, Alexandre

--- a/datasets/satellogic-earthview.yaml
+++ b/datasets/satellogic-earthview.yaml
@@ -28,6 +28,6 @@ Resources:
     - '[STAC Browser](https://radiantearth.github.io/stac-browser/#/external/satellogic-earthview.s3.us-west-2.amazonaws.com/stac/catalog.json)'
 DataAtWork:
   Publications:
-    - Title: EarthView: A Large Scale Remote Sensing Dataset for Self-Supervision
+    - Title: "EarthView: A Large Scale Remote Sensing Dataset for Self-Supervision"
       URL: https://satellogic-earthview.s3.us-west-2.amazonaws.com/index.html
       AuthorName: Velázquez, Diego and Rodríguez, Pau and Alonso, Sergio and Gonfaus, Josep M. and González, Jordi and, Richarte, Gerardo and Marín, Javier and Bengio, Yoshua and Lacoste, Alexandre


### PR DESCRIPTION
Adding Satellogic EarthView dataset yaml

*Description of changes:*

This PR incorporates the new Satellogic EarthView dataset yaml to the AWS Open Data Registry datasets.

The dataset has been made available under the CC BY 4.0 license.
