### PR TITLE
Update satellogic-earthview.yaml

### DIFF
--- a/datasets/satellogic-earthview.yaml
+++ b/datasets/satellogic-earthview.yaml
@@ -24,6 +24,13 @@ Resources:
     - '[STAC Catalog](https://satellogic-earthview.s3.us-west-2.amazonaws.com/stac/catalog.json)'
     - '[STAC Browser](https://radiantearth.github.io/stac-browser/#/external/satellogic-earthview.s3.us-west-2.amazonaws.com/stac/catalog.json)'
 DataAtWork:
+  Tutorials:
+    - Title: Explore Satellogic EarthView in SageMaker Studio Lab (SMSL)
+      URL: https://github.com/satellogic/satellogic-earthview/
+      NotebookURL: https://github.com/satellogic/satellogic-earthview/blob/main/satellogic_earthview_exploration.ipynb
+      AuthorName: Javier Marin
+      Services:
+      - SageMaker Studio Lab
   Publications:
     - Title: "EarthView: A Large Scale Remote Sensing Dataset for Self-Supervision"
       URL: https://satellogic-earthview.s3.us-west-2.amazonaws.com/index.html


### PR DESCRIPTION
Adding link to notebook compatible with SMSL

The original notebook comes now with an environment.yml to make it work in SMSL.

