### PR TITLE
Updated links in geoschem-nested-input-data & geoschem-input-data

### DIFF
--- a/datasets/geoschem-input-data.yaml
+++ b/datasets/geoschem-input-data.yaml
@@ -1,6 +1,6 @@
 Name: GEOS-Chem Input Data
 Description: Input data for the GEOS-Chem Chemical Transport Model, includes NASA/GMAO MERRA-2 and GEOS-FP [meteorological products](https://geos-chem.readthedocs.io/en/latest/gcclassic-user-guide/input-overview.html#met), [chemistry input data](https://geos-chem.readthedocs.io/en/latest/gcclassic-user-guide/input-overview.html#chemistry-input-data), [emissions input data](https://geos-chem.readthedocs.io/en/latest/gcclassic-user-guide/input-overview.html#emis-inputs), and other smaller datasets such as model [initial conditions](https://geos-chem.readthedocs.io/en/latest/gcclassic-user-guide/input-overview.html#initial-conditions-input-data>).
-Documentation: https://geos-chem.readthedocs.io/en/latest/geos-chem-shared-docs/supplemental-guides/geos-chem-input-data-on-aws.html
+Documentation: https://geos-chem.readthedocs.io/en/stable/geos-chem-shared-docs/doc/gcid-portal-overview.html
 Contact: https://geoschem.github.io/support-team.html
 UpdateFrequency: New meteorological and emission data will be added when available.
 ManagedBy: "[GEOS-Chem Support Team](https://geoschem.github.io/support-team.html)"
@@ -18,6 +18,7 @@ Tags:
   - chemistry
   - atmosphere
   - model
+  - inversions
 License: https://geoschem.github.io/license.html
 Resources:
   - Description: Top-level directory for all GEOS-Chem data.
@@ -28,18 +29,22 @@ Resources:
     - '[Browse Bucket](https://geos-chem.s3.amazonaws.com/index.html)'
 DataAtWork:
   Tutorials:
-    - Title: Getting started with GEOS-Chem Input Data
-      URL: https://geos-chem.readthedocs.io/en/latest/geos-chem-shared-docs/supplemental-guides/getting-started-aws.html
+    - Title: GEOS-Chem Input Data on AWS cloud
+      URL: https://geos-chem.readthedocs.io/en/stable/geos-chem-shared-docs/doc/gcid-portal-overview.html
       AuthorName: GEOS-Chem Support Team
       AuthorURL: http://geos-chem.org/support-team
     - Title: GEOS-Chem Classic Quickstart Guide
-      URL: https://geos-chem.readthedocs.io/en/latest/getting-started/quick-start.html
+      URL: https://geos-chem.readthedocs.io/en/stable/getting-started/quick-start.html
       AuthorName: GEOS-Chem Support Team
       AuthorURL: http://geos-chem.org/support-team
     - Title: GCHP Quickstart Guide
-      URL: https://gchp.readthedocs.io/en/latest/getting-started/quick-start.html
+      URL: https://gchp.readthedocs.io/en/stable/getting-started/quick-start.html
       AuthorName: GEOS-Chem Support Team
       AuthorURL: http://geos-chem.org/support-team
+    - Title: Integrated Methane Inversion (IMI) Quickstart Guide
+      URL: https://imi.readthedocs.io/en/latest/getting-started/quick-start.html
+      AuthorName: Daniel Varon et al.
+      AuthorURL: http://carboninversion.com/people
   Tools & Applications:
   Publications:
     - Title: "Enabling Immediate Access to Earth Science Models through Cloud Computing: Application to the GEOS-Chem Model"

--- a/datasets/geoschem-input-data.yaml
+++ b/datasets/geoschem-input-data.yaml
@@ -18,7 +18,6 @@ Tags:
   - chemistry
   - atmosphere
   - model
-  - inversions
 License: https://geoschem.github.io/license.html
 Resources:
   - Description: Top-level directory for all GEOS-Chem data.

--- a/datasets/geoschem-nested-input-data.yaml
+++ b/datasets/geoschem-nested-input-data.yaml
@@ -1,6 +1,6 @@
 Name: GEOS-Chem Nested Input Data
 Description: Input data for nested-grid simulations using the GEOS-Chem Chemical Transport Model. This includes the NASA/GMAO MERRA-2 and GEOS-FP [meteorological products](https://geos-chem.readthedocs.io/en/latest/gcclassic-user-guide/input-overview.html#met), the [HEMCO emission inventories](https://geos-chem.readthedocs.io/en/latest/gcclassic-user-guide/input-overview.html#emis-inputs), and other small data such as [model initial conditions](https://geos-chem.readthedocs.io/en/latest/gcclassic-user-guide/restart-files.html).
-Documentation: https://geos-chem.readthedocs.io
+Documentation: https://geos-chem.readthedocs.io/en/stable/geos-chem-shared-docs/doc/gcid-special-portals.html#geos-chem-nested-input-data
 Contact: http://geos-chem.org/support-team
 UpdateFrequency: New meteorological and emission data will be added when available.
 ManagedBy: "[GEOS-Chem Support Team](https://geoschem.github.io/support-team.html)"
@@ -28,6 +28,10 @@ Resources:
     - '[Browse Bucket](https://s3.amazonaws.com/gcgrid/index.html)'
 DataAtWork:
   Tutorials:
+    - Title: GEOS-Chem nested input data
+      URL: https://geos-chem.readthedocs.io/en/stable/geos-chem-shared-docs/doc/gcid-special-portals.html#geos-chem-nested-input-data
+      AuthorName: GEOS-Chem Support Team
+      AuthorURL: http://geos-chem.org/support-team
     - Title: GEOS-Chem input data on AWS cloud
       URL: https://geos-chem.readthedocs.io/en/latest/geos-chem-shared-docs/supplemental-guides/geos-chem-input-data-on-aws.html
       AuthorName: GEOS-Chem Support Team
@@ -42,9 +46,9 @@ DataAtWork:
       AuthorURL: http://geos-chem.org/support-team
   Tools & Applications:
     - Title: Integrated Methane Inversion
-      URL: https://imi.seas.harvard.edu/
+      URL: https://carboninversion.com
       AuthorName: Daniel Varon et al.
-      AuthorURL: https://imi.seas.harvard.edu/people
+      AuthorURL: https://carboninversion.com/people/
   Publications:
     - Title: "Enabling Immediate Access to Earth Science Models through Cloud Computing: Application to the GEOS-Chem Model"
       URL: https://doi.org/10.1175/BAMS-D-18-0243.1


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

This PR updates several broken links in `datasets/geoschem-input-data.yaml` and `datasets/geoschem-nested-input-data.yaml`, as described below:

`datasets/geoschem-input-data.yaml`
- Documentation link now points to proper URL
- Added "inversions" keyword
- Replaced "Getting started with GEOS-Chem Input Data" with "GEOS-Chem Input Data on AWS Cloud" (with link updates as well)
- GEOS-Chem Classic and GCHP quickstart guides now point to "stable"
- Added IMI quickstart guide links

`datasets/geoschem-nested-input-data.yaml`
- Updated documentation URL
- Added tutoral for GEOS-Chem nested input data
- Updated Integrated Methane Inversion website URLs

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
