### PR TITLE
Add tutorial link and modify dynamic STAC link to PGC registry pages

### DIFF
--- a/datasets/pgc-arcticdem.yaml
+++ b/datasets/pgc-arcticdem.yaml
@@ -34,8 +34,12 @@ Resources:
     Type: S3 Bucket
     Explore:
       - '[Browse Static STAC Catalog](https://polargeospatialcenter.github.io/stac-browser/#/external/pgc-opendata-dems.s3.us-west-2.amazonaws.com/arcticdem/strips.json)'
-      - '[Dynamic STAC API Endpoint](https://stac.pgc.umn.edu/api/v1/)'
+      - '[Dynamic STAC API Guide](https://www.pgc.umn.edu/guides/stereo-derived-elevation-models/stac-access-static-and-dynamic-api/)'
 DataAtWork:
+  Tutorials:
+    - Title: PGC Dynamic STAC API Tutorial
+      URL: https://polargeospatialcenter.github.io/pgc-code-tutorials/dynamic_stac_api/web_files/stac_api_demo_workflow.html
+      AuthorName: Polar Geospatial Centerv
   Tools & Applications:
     - Title: ArcticDEM Explorer
       URL: https://arcticdem.apps.pgc.umn.edu/

--- a/datasets/pgc-earthdem.yaml
+++ b/datasets/pgc-earthdem.yaml
@@ -27,8 +27,12 @@ Resources:
     Type: S3 Bucket
     Explore:
       - '[Browse Static STAC Catalog](https://polargeospatialcenter.github.io/stac-browser/#/external/pgc-opendata-dems.s3.us-west-2.amazonaws.com/earthdem/strips.json)'
-      - '[Dynamic STAC API Endpoint](https://stac.pgc.umn.edu/api/v1/)'
+      - '[Dynamic STAC API Guide](https://www.pgc.umn.edu/guides/stereo-derived-elevation-models/stac-access-static-and-dynamic-api/)'
 DataAtWork:
+  Tutorials:
+    - Title: PGC Dynamic STAC API Tutorial
+      URL: https://polargeospatialcenter.github.io/pgc-code-tutorials/dynamic_stac_api/web_files/stac_api_demo_workflow.html
+      AuthorName: Polar Geospatial Center
   Tools & Applications:
     - Title: GLARS Data Viewer
       URL: https://glars.org/data/view-and-download/

--- a/datasets/pgc-rema.yaml
+++ b/datasets/pgc-rema.yaml
@@ -34,8 +34,12 @@ Resources:
     Type: S3 Bucket
     Explore:
       - '[Browse Static STAC Catalog](https://polargeospatialcenter.github.io/stac-browser/#/external/pgc-opendata-dems.s3.us-west-2.amazonaws.com/rema/strips.json)'
-      - '[Dynamic STAC API Endpoint](https://stac.pgc.umn.edu/api/v1/)'
+      - '[Dynamic STAC API Guide](https://www.pgc.umn.edu/guides/stereo-derived-elevation-models/stac-access-static-and-dynamic-api/)'
 DataAtWork:
+  Tutorials:
+    - Title: PGC Dynamic STAC API Tutorial
+      URL: https://polargeospatialcenter.github.io/pgc-code-tutorials/dynamic_stac_api/web_files/stac_api_demo_workflow.html
+      AuthorName: Polar Geospatial Center
   Tools & Applications:
     - Title: REMA Explorer
       URL: https://rema.apps.pgc.umn.edu/


### PR DESCRIPTION
*Issue #, if available:*
NA

*Description of changes:*
Added tutorial link to a new dynamic STAC API tutorial
Modified dynamic STAC link to PGC registry pages to point to the guide instead of just the endpoint

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
