### PR TITLE
Adding Amazon Forest canopy Height from CTrees

### DIFF
--- a/datasets/ctrees-amazon-canopy-height.yaml
+++ b/datasets/ctrees-amazon-canopy-height.yaml
@@ -1,0 +1,37 @@
+Name: Canopy Tree Height maps for the Amazon Forest (mean height composite 2020-2024) by CTrees.org
+Description: |
+  Mean canopy Tree Height for the Amazon Forest on the period 2020-2024 at 4.78 m of spatial resolution. Created using a deep learning model on high-resolution Planet imagery from the Norway's International Climate and Forest Initiative (NICFI) Satellite Data Program.
+Documentation: "[Project overview](https://ctrees.org/products/tree-level)"
+Contact: info@ctrees.org
+ManagedBy: "[CTrees](https://ctrees.org/)"
+UpdateFrequency: TBD
+Tags:
+  - aws-pds
+  - cog
+  - earth observation
+  - land cover
+  - deep learning
+  - aerial LiDAR
+  - satellite imagery
+  - image processing
+  - environmental
+  - conservation
+  - geospatial
+License: |
+  https://creativecommons.org/licenses/by/4.0/
+Citation: CTrees.org - 2025. Canopy Tree Height of the Amazon Forest. Accessed DAY MONTH YEAR.
+Resources:
+  - Description: Cloud-optimized GeoTIFF files with names corresponding to the tiling system of the Norway's International Climate and Forest Initiative (NICFI) Satellite Data Program.
+    ARN: TBD
+    Region: us-west-2
+    Type: S3 Bucket
+DataAtWork:
+  Tutorials:
+  Tools & Applications:
+  Publications:
+    - Title: "Is this the largest tree in the Amazon? A Q&A with CTrees scientist Fabien Wagner"
+      URL: https://ctrees.org/news/largest-tree-amazon-with-fabien-wagner-63
+      AuthorName: Rachel Kovinsky
+    - Title: "High Resolution Tree Height Mapping of the Amazon Forest using Planet NICFI Images and LiDAR-Informed U-Net Model"
+      URL: https://doi.org/10.48550/arXiv.2501.10600
+      AuthorName: Fabien H Wagner, Ricardo Dalagnol, Griffin Carter, Mayumi CM Hirye, Shivraj Gill, Le Bienfaiteur Sagang Takougoum, Samuel Favrichon, Michael Keller, Jean PHB Ometto, Lorena Alves, Cynthia Creze, Stephanie P George-Chacon, Shuang Li, Zhihua Liu, Adugna Mullissa, Yan Yang, Erone G Santos, Sarah R Worden, Martin Brandt, Philippe Ciais, Stephen C Hagen, Sassan Saatchi


### PR DESCRIPTION
*Description of changes:*
Request to add canopy height for amazon forest dataset from CTrees. Online submission request sent May 5, 2025. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
