### PR TITLE
Add Clay datasets from Source Cooperative

### DIFF
--- a/datasets/clay-model-v0-embeddings.yaml
+++ b/datasets/clay-model-v0-embeddings.yaml
@@ -1,0 +1,27 @@
+Name: Clay Model v0 Embeddings
+Description: Machine learning model embeddings dataset providing pre-computed feature representations for satellite and aerial imagery analysis.
+Documentation: https://source.coop/repositories/clay/clay-model-v0-embeddings/description
+Contact: contact@madewithclay.org
+ManagedBy: "[Source Cooperative](https://source.coop/)"
+UpdateFrequency: As new model versions become available
+Tags:
+  - aws-pds
+  - machine learning
+  - embeddings
+  - computer vision
+  - satellite imagery
+  - aerial imagery
+  - feature extraction
+  - ai
+License: Creative Commons Attribution 4.0 International License
+Citation: "Clay Model v0 Embeddings. Source Cooperative. https://source.coop/repositories/clay/clay-model-v0-embeddings/description"
+Resources:
+  - Description: Clay Model v0 Embeddings S3 Bucket
+    ARN: arn:aws:s3:::us-west-2.opendata.source.coop/clay/clay-model-v0-embeddings
+    Region: us-west-2
+    Type: S3 Bucket
+    Explore:
+    - '[Browse Dataset](https://source.coop/clay/clay-model-v0-embeddings/)'
+ADXCategories:
+  - Machine Learning Data
+  - Computer Vision Data 

--- a/datasets/clay-model-v0-embeddings.yaml
+++ b/datasets/clay-model-v0-embeddings.yaml
@@ -5,14 +5,12 @@ Contact: contact@madewithclay.org
 ManagedBy: "[Source Cooperative](https://source.coop/)"
 UpdateFrequency: As new model versions become available
 Tags:
-  - aws-pds
   - machine learning
-  - embeddings
   - computer vision
   - satellite imagery
   - aerial imagery
-  - feature extraction
-  - ai
+  - earth observation
+  - imaging
 License: Creative Commons Attribution 4.0 International License
 Citation: "Clay Model v0 Embeddings. Source Cooperative. https://source.coop/repositories/clay/clay-model-v0-embeddings/description"
 Resources:

--- a/datasets/clay-model-v0-embeddings.yaml
+++ b/datasets/clay-model-v0-embeddings.yaml
@@ -21,5 +21,4 @@ Resources:
     Explore:
     - '[Browse Dataset](https://source.coop/clay/clay-model-v0-embeddings/)'
 ADXCategories:
-  - Machine Learning Data
-  - Computer Vision Data 
+  - Environmental Data 

--- a/datasets/clay-v1-5-naip-2.yaml
+++ b/datasets/clay-v1-5-naip-2.yaml
@@ -5,13 +5,10 @@ Contact: contact@madewithclay.org
 ManagedBy: "[Source Cooperative](https://source.coop/)"
 UpdateFrequency: As new NAIP data becomes available
 Tags:
-  - aws-pds
   - aerial imagery
-  - naip
   - agriculture
   - land use
-  - natural resources
-  - remote sensing
+  - natural resource
   - environmental
 License: Creative Commons Attribution 4.0 International License
 Citation: "Clay v1.5 NAIP-2. Source Cooperative. https://source.coop/repositories/clay/clay-v1-5-naip-2/description"

--- a/datasets/clay-v1-5-naip-2.yaml
+++ b/datasets/clay-v1-5-naip-2.yaml
@@ -20,5 +20,4 @@ Resources:
     Explore:
     - '[Browse Dataset](https://source.coop/clay/clay-v1-5-naip-2/)'
 ADXCategories:
-  - Earth Observation Data
-  - Aerial Imagery 
+  - Environmental Data 

--- a/datasets/clay-v1-5-naip-2.yaml
+++ b/datasets/clay-v1-5-naip-2.yaml
@@ -1,0 +1,27 @@
+Name: Clay v1.5 NAIP-2
+Description: National Agriculture Imagery Program (NAIP) dataset providing high-resolution aerial imagery for agricultural monitoring, land use analysis, and natural resource management.
+Documentation: https://source.coop/repositories/clay/clay-v1-5-naip-2/description
+Contact: contact@madewithclay.org
+ManagedBy: "[Source Cooperative](https://source.coop/)"
+UpdateFrequency: As new NAIP data becomes available
+Tags:
+  - aws-pds
+  - aerial imagery
+  - naip
+  - agriculture
+  - land use
+  - natural resources
+  - remote sensing
+  - environmental
+License: Creative Commons Attribution 4.0 International License
+Citation: "Clay v1.5 NAIP-2. Source Cooperative. https://source.coop/repositories/clay/clay-v1-5-naip-2/description"
+Resources:
+  - Description: Clay v1.5 NAIP-2 S3 Bucket
+    ARN: arn:aws:s3:::us-west-2.opendata.source.coop/clay/clay-v1-5-naip-2
+    Region: us-west-2
+    Type: S3 Bucket
+    Explore:
+    - '[Browse Dataset](https://source.coop/clay/clay-v1-5-naip-2/)'
+ADXCategories:
+  - Earth Observation Data
+  - Aerial Imagery 

--- a/datasets/clay-v1-5-sentinel2.yaml
+++ b/datasets/clay-v1-5-sentinel2.yaml
@@ -5,11 +5,8 @@ Contact: contact@madewithclay.org
 ManagedBy: "[Source Cooperative](https://source.coop/)"
 UpdateFrequency: As new Sentinel-2 data becomes available
 Tags:
-  - aws-pds
   - satellite imagery
-  - sentinel-2
   - earth observation
-  - remote sensing
   - agriculture
   - land monitoring
   - environmental

--- a/datasets/clay-v1-5-sentinel2.yaml
+++ b/datasets/clay-v1-5-sentinel2.yaml
@@ -1,0 +1,29 @@
+Name: Clay v1.5 Sentinel-2
+Description: Sentinel-2 satellite imagery dataset providing high-resolution optical data for land monitoring, agriculture, and environmental applications.
+Documentation: https://source.coop/repositories/clay/clay-v1-5-sentinel2/description
+Contact: contact@madewithclay.org
+ManagedBy: "[Source Cooperative](https://source.coop/)"
+UpdateFrequency: As new Sentinel-2 data becomes available
+Tags:
+  - aws-pds
+  - satellite imagery
+  - sentinel-2
+  - earth observation
+  - remote sensing
+  - agriculture
+  - land monitoring
+  - environmental
+License: Creative Commons Attribution 4.0 International License
+Citation: "Clay v1.5 Sentinel-2. Source Cooperative. https://source.coop/repositories/clay/clay-v1-5-sentinel2/description"
+Resources:
+  - Description: Clay v1.5 Sentinel-2 S3 Bucket
+    ARN: arn:aws:s3:::us-west-2.opendata.source.coop/clay/clay-v1-5-sentinel2
+    Region: us-west-2
+    Type: S3 Bucket
+    Explore:
+    - '[Browse Dataset](https://source.coop/repositories/clay/clay-v1-5-sentinel2/description)'
+ADXCategories:
+  - Earth Observation Data
+  - Satellite Imagery 
+
+

--- a/datasets/clay-v1-5-sentinel2.yaml
+++ b/datasets/clay-v1-5-sentinel2.yaml
@@ -20,7 +20,6 @@ Resources:
     Explore:
     - '[Browse Dataset](https://source.coop/repositories/clay/clay-v1-5-sentinel2/description)'
 ADXCategories:
-  - Earth Observation Data
-  - Satellite Imagery 
+  - Environmental Data 
 
 

--- a/datasets/clay-v1-5-sentinel2.yaml
+++ b/datasets/clay-v1-5-sentinel2.yaml
@@ -8,7 +8,7 @@ Tags:
   - satellite imagery
   - earth observation
   - agriculture
-  - land monitoring
+  - land use
   - environmental
 License: Creative Commons Attribution 4.0 International License
 Citation: "Clay v1.5 Sentinel-2. Source Cooperative. https://source.coop/repositories/clay/clay-v1-5-sentinel2/description"


### PR DESCRIPTION
## Summary
This PR adds three new dataset entries to the Registry of Open Data on AWS (RODA) that correspond to data products published via Source Cooperative.

## Datasets Added
  - [Clay v1.5 Sentinel-2](https://source.coop/clay/clay-v1-5-sentinel2/)
  - [Clay v1.5 NAIP-2](https://source.coop/clay/clay-v1-5-naip-2/)
  - [Clay Model v0 Embeddings](https://source.coop/clay/clay-model-v0-embeddings/)

Open to feedback on this, particularly from the Clay team. 