### PR TITLE
software-heritage: Update links to documentation

### DIFF
--- a/datasets/software-heritage.yaml
+++ b/datasets/software-heritage.yaml
@@ -14,7 +14,7 @@ Description: |
     information is also included, providing timestamps about when and where all
     archived source code artifacts have been observed in the wild.
     Author and committer information is anonymized.
-Documentation: https://docs.softwareheritage.org/devel/swh-dataset/graph/athena.html
+Documentation: https://docs.softwareheritage.org/devel/swh-export/graph/athena.html
 Contact: aws@softwareheritage.org
 ManagedBy: Software Heritage
 UpdateFrequency: Data is updated yearly
@@ -48,11 +48,11 @@ Resources:
 DataAtWork:
   Tutorials:
     - Title: Using the Software Heritage Graph Dataset
-      URL: https://docs.softwareheritage.org/devel/swh-dataset/graph/index.html
+      URL: https://docs.softwareheritage.org/devel/swh-export/graph/
       AuthorName: The Software Heritage team
   Tools & Applications:
     - Title: The SWH-Graph module
-      URL: https://docs.softwareheritage.org/devel/swh-graph/index.html
+      URL: https://docs.softwareheritage.org/devel/swh-graph/
       AuthorName: The Software Heritage team
   Publications:
     - Title: The Software Heritage Graph Dataset


### PR DESCRIPTION
*Description of changes:*

* https://docs.softwareheritage.org/devel/swh-dataset/graph/index.html is a dead link (we are going to add a redirect shortly, though)
* https://docs.softwareheritage.org/devel/swh-dataset/graph/athena.html redirects to https://docs.softwareheritage.org/devel/swh-export/graph/athena.html
* remove unnecessary `/index.html` at the end of links

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
