### PR TITLE
Add xReverseLabs Domain Dataset

### DIFF
--- a/datasets/xreverselabs-domain-dataset.yaml
+++ b/datasets/xreverselabs-domain-dataset.yaml
@@ -1,0 +1,47 @@
+Name: xReverseLabs Domain Dataset
+Description: >
+  The xReverseLabs Domain Dataset provides open collections of domain names and
+  their associated DNS records. It includes daily domain dumps, historical domain
+  data, domain lists grouped by TLD/extension, and a Forward DNS (FDNS) dataset
+  containing resolved domain-to-IP mappings with metadata. The dataset is designed
+  to support cybersecurity, threat intelligence, and internet-scale research.
+Documentation: https://opendata.xreverselabs.org/docs/
+Contact: opendata@xreverselabs.org
+ManagedBy: xReverseLabs
+UpdateFrequency: Daily
+Tags:
+  - dns
+  - internet
+  - domains
+  - reverse-dns
+  - cybersecurity
+  - threat-intelligence
+License: CC-BY-4.0
+Resources:
+  - Description: Daily Domain Dump Dataset (list of domains updated daily)
+    ARN: arn:aws:s3:::xreverselabs-domain-dataset/daily/*
+    Region: us-west-2
+    Type: S3 Bucket
+  - Description: Domain By Date Full Data (historical daily new domains)
+    ARN: arn:aws:s3:::xreverselabs-domain-dataset/by-date/*
+    Region: us-west-2
+    Type: S3 Bucket
+  - Description: Domain By Extension Dataset (grouped by TLD/extension)
+    ARN: arn:aws:s3:::xreverselabs-domain-dataset/by-extension/*
+    Region: us-west-2
+    Type: S3 Bucket
+  - Description: Forward DNS Dataset (FDNS JSON records with IPs)
+    ARN: arn:aws:s3:::xreverselabs-domain-dataset/fdns/*
+    Region: us-west-2
+    Type: S3 Bucket
+DataAtWork:
+  Tutorials:
+    - Title: Get To Know A Dataset: xReverseLabs Domain Dataset
+      URL: https://github.com/xreverselabs/open-data-examples/blob/main/xreverselabs/get-to-know-a-dataset.ipynb
+      AuthorName: xReverseLabs
+      AuthorURL: https://xreverselabs.org
+  Publications: []
+  Tools & Applications: []
+Citation: >
+  Please cite as: xReverseLabs Domain Dataset, available at
+  https://registry.opendata.aws/xreverselabs-domain-dataset

--- a/datasets/xreverselabs-domain-dataset.yaml
+++ b/datasets/xreverselabs-domain-dataset.yaml
@@ -37,7 +37,7 @@ Resources:
 DataAtWork:
   Tutorials:
     - Title: Get To Know A Dataset: xReverseLabs Domain Dataset
-      URL: https://github.com/xreverselabs/open-data-examples/blob/main/xreverselabs/get-to-know-a-dataset.ipynb
+      URL: https://github.com/xReverseLabs/open-data-examples/blob/main/get-to-know-a-dataset.ipynb
       AuthorName: xReverseLabs
       AuthorURL: https://opendata.xreverselabs.org
   Publications: []
@@ -45,3 +45,4 @@ DataAtWork:
 Citation: >
   Please cite as: xReverseLabs Domain Dataset, available at
   https://registry.opendata.aws/xreverselabs-domain-dataset
+

--- a/datasets/xreverselabs-domain-dataset.yaml
+++ b/datasets/xreverselabs-domain-dataset.yaml
@@ -5,7 +5,7 @@ Description: >
   data, domain lists grouped by TLD/extension, and a Forward DNS (FDNS) dataset
   containing resolved domain-to-IP mappings with metadata. The dataset is designed
   to support cybersecurity, threat intelligence, and internet-scale research.
-Documentation: https://opendata.xreverselabs.org/docs/
+Documentation: https://opendata.xreverselabs.org/about.php
 Contact: opendata@xreverselabs.org
 ManagedBy: xReverseLabs
 UpdateFrequency: Daily
@@ -39,7 +39,7 @@ DataAtWork:
     - Title: Get To Know A Dataset: xReverseLabs Domain Dataset
       URL: https://github.com/xreverselabs/open-data-examples/blob/main/xreverselabs/get-to-know-a-dataset.ipynb
       AuthorName: xReverseLabs
-      AuthorURL: https://xreverselabs.org
+      AuthorURL: https://opendata.xreverselabs.org
   Publications: []
   Tools & Applications: []
 Citation: >


### PR DESCRIPTION
*Description of changes:*
This pull request adds the xReverseLabs Domain Dataset to the AWS Open Data Registry.

Dataset details:
- Daily Domain Dump Dataset (plain text, one domain per line)
- Domain by Date Full Data (historical daily unique domains)
- Domain by Extension Dataset (domains grouped by TLD, .txt.gz format)
- Forward DNS (FDNS) Dataset (JSON records of DNS resolutions)

Repository with example notebooks:
https://github.com/xReverseLabs/open-data-examples

Documentation:
https://opendata.xreverselabs.org/about.php

*License:* CC-BY 4.0

This dataset supports threat intelligence, academic research, and large-scale DNS measurements.
