### PR TITLE
add LongBench dataset

### DIFF
--- a/datasets/longbench.yaml
+++ b/datasets/longbench.yaml
@@ -12,7 +12,6 @@ Tags:
   - short read sequencing
   - bioinformatics
   - fastq
-  - pod5
   - bam
   - vcf
   - cancer


### PR DESCRIPTION
*Description of changes:*

Add _LongBench_ dataset — a comprehensive benchmark dataset of the latest long-read transcriptomics technologies from Oxford Nanopore (ONT) and Pacific Biosciences, alongside a comparison with next-generation sequencing from Illumina.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution under the terms of your choice.
