### PR TITLE
Include the year 2024 in the description of the EOT Web Archive dataset

### DIFF
--- a/datasets/eot-web-archive.yaml
+++ b/datasets/eot-web-archive.yaml
@@ -3,7 +3,7 @@ Description: >
   The End of Term Web Archive (EOT) captures and saves U.S.
   Government websites at the end of presidential administrations.  The EOT has
   thus far preserved websites from administration changes in 2008, 2012, 2016,
-  and 2020.  Data from these web crawls have been made openly available in
+  2020, and 2024.  Data from these web crawls have been made openly available in
   several formats in this dataset.
 Documentation: https://eotarchive.org/data/
 Contact: Mark Phillips <mark.phillips@unt.edu>, Sawood Alam <sawood@archive.org>


### PR DESCRIPTION
*Description of changes:*

Updating the description to include year 2024 as the End of Term 2024 datasets are now being uploaded to AWS.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
