### PR TITLE
Added XRISM and SRG-eROSITA resource entries to the NASA-HEASARC open dataset description

### DIFF
--- a/datasets/nasa-heasarc.yaml
+++ b/datasets/nasa-heasarc.yaml
@@ -24,6 +24,7 @@ Tags:
   - imaging
   - satellite imagery
   - x-ray
+
 License: See [the HEASARC data policy web site](https://heasarc.gsfc.nasa.gov/docs/heasarc/data_policy.html)
 Citation: See [the HEASARC data policy web site](https://heasarc.gsfc.nasa.gov/docs/heasarc/data_policy.html)
 Resources:
@@ -142,7 +143,7 @@ Resources:
    Region: us-east-1
    Type: S3 Bucket
 
- - Description: The [SRG Mission](https://heasarc.gsfc.nasa.gov/docs/heasarc/missions/srg.html) eROSITA Instrument Data Archive. More information available at [the eROSITA support site](https://heasarc.gsfc.nasa.gov/docs/srg/erosita/). Total size > 3 TB.
+ - Description: "The [SRG Mission](https://heasarc.gsfc.nasa.gov/docs/heasarc/missions/srg.html) eROSITA Instrument Data Archive. More information available at [the eROSITA support site](https://heasarc.gsfc.nasa.gov/docs/srg/erosita/). Total size > 3 TB."
    ARN: arn:aws:s3:::nasa-heasarc/srg/data/erosita/
    Region: us-east-1
    Type: S3 Bucket
@@ -177,7 +178,7 @@ Resources:
    Region: us-east-1
    Type: S3 Bucket
 
-- Description: The [XRISM Mission](https://heasarc.gsfc.nasa.gov/docs/heasarc/missions/xrism.html) Data Archive.  Total size > 1 TB.
+- Description: "The [XRISM Mission](https://heasarc.gsfc.nasa.gov/docs/heasarc/missions/xrism.html) Data Archive.  Total size > 1 TB."
   ARN: arn:aws:s3:::nasa-heasarc/xrism/data/obs/
   Region: us-east-1
   Type: S3 Bucket

--- a/datasets/nasa-heasarc.yaml
+++ b/datasets/nasa-heasarc.yaml
@@ -178,10 +178,10 @@ Resources:
    Region: us-east-1
    Type: S3 Bucket
 
-- Description: "The [XRISM Mission](https://heasarc.gsfc.nasa.gov/docs/heasarc/missions/xrism.html) Data Archive.  Total size > 1 TB."
-  ARN: arn:aws:s3:::nasa-heasarc/xrism/data/obs/
-  Region: us-east-1
-  Type: S3 Bucket
+ - Description: "The [XRISM Mission](https://heasarc.gsfc.nasa.gov/docs/heasarc/missions/xrism.html) Data Archive.  Total size > 1 TB."
+   ARN: arn:aws:s3:::nasa-heasarc/xrism/data/obs/
+   Region: us-east-1
+   Type: S3 Bucket
 
 DataAtWork:
   Tutorials:

--- a/datasets/nasa-heasarc.yaml
+++ b/datasets/nasa-heasarc.yaml
@@ -24,7 +24,6 @@ Tags:
   - imaging
   - satellite imagery
   - x-ray
-
 License: See [the HEASARC data policy web site](https://heasarc.gsfc.nasa.gov/docs/heasarc/data_policy.html)
 Citation: See [the HEASARC data policy web site](https://heasarc.gsfc.nasa.gov/docs/heasarc/data_policy.html)
 Resources:


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:* Added two resource entries to the NASA-HEASARC open-registry entry; one for the XRISM telescope's data, and one for the SRG telescope's eROSITA instrument data. Both follow the pattern of the other resource entries. Both sets of observations are already available in the HEASARC open dataset.

Tagging @trjaffe so she is aware of these changes and this PR.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
