### PR TITLE
Add coral reef image classification training data to AWS Open Data registry

### DIFF
--- a/datasets/coralreef-image-classification-training.yaml
+++ b/datasets/coralreef-image-classification-training.yaml
@@ -5,6 +5,7 @@ Contact: contact@datamermaid.org
 ManagedBy: "[MERMAID](https://datamermaid.org/)"
 UpdateFrequency: Each partner organization updates on their own cadence. MERMAID updates once per day.
 Tags:
+  - aws-pds
   - coastal
   - conservation
   - coral reef


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This pull request adds an open, well-structured, growing, community-sourced repository of coral reef image classification training data to the AWS Open Data registry. Documentation and tutorial:
https://github.com/data-mermaid/image-classification-open-data

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
