### PR TITLE
adding planette_era5 archive

### DIFF
--- a/datasets/planette_era5_reanalysis.yaml
+++ b/datasets/planette_era5_reanalysis.yaml
@@ -66,4 +66,4 @@ DataAtWork:
       AuthorName: ECMWF
 DeprecatedNotice:
 ADXCategories:
-  - Environmental Data 
+  - Environmental Data


### PR DESCRIPTION
This is an addition of the planette_era5 archive to this fork of the aws open data registry to mitigate issues I was having with allowing upstream maintainers to edit the PR when using the planette account

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
