### PR TITLE
Add Scigantic notebook to NEXRAD

### DIFF
--- a/datasets/noaa-nexrad.yaml
+++ b/datasets/noaa-nexrad.yaml
@@ -78,6 +78,10 @@ DataAtWork:
       AuthorName: Chris Stoner
       Services:
       - Amazon SageMaker Studio Lab
+    - Title: Explore NEXRAD in a Browser-Based Notebook with Scigantic
+      URL: https://scigantic.com/archive/b2c6e420-9855-55ce-af73-f8e41a24278e/sample
+      AuthorName: Scigantic
+      AuthorURL: https://scigantic.com
   Tools & Applications:
     - Title: nexradaws on pypi.python.org - python module to query and download Nexrad data from Amazon S3
       URL: https://pypi.org/project/nexradaws/


### PR DESCRIPTION
  DataAtWork

*Issue #, if available:*

*Description of changes:*

Spoke with @cstner on April 15th, 2026 (thanks again Chris!) -- this notebook is an example of how to leverage the NEXRAD data (from AWS Registry of Open Data) on Scigantic

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
