### PR TITLE
dynamical.org: add cross-model heating degree day example + remove preliminary note 

### DIFF
--- a/datasets/dynamical-ecmwf-aifs-single.yaml
+++ b/datasets/dynamical-ecmwf-aifs-single.yaml
@@ -1,14 +1,7 @@
 Name: ECMWF AIFS Single - dynamical.org Icechunk Zarr
 Description: |
-    <p>
-      The Artificial Intelligence Forecasting System (AIFS) is a data driven forecast
-      model developed by the European Centre for Medium-Range Weather Forecasts (ECMWF).
-      This is the non-ensemble configuration of AIFS that produces a single forecast trace.
-      AIFS is trained on ECMWF's ERA5 re-analysis and ECMWF's operational numerical
-      weather prediction (NWP) analyses.
-      </p>
+    <p>The Artificial Intelligence Forecasting System (AIFS) is a data driven forecast model developed by the European Centre for Medium-Range Weather Forecasts (ECMWF). This is the non-ensemble configuration of AIFS that produces a single forecast trace. AIFS is trained on ECMWF's ERA5 re-analysis and ECMWF's operational numerical weather prediction (NWP) analyses.</p>
     <p>These datasets have been translated to cloud-optimized Icechunk Zarr format by <a href="https://dynamical.org">dynamical.org</a>.</p>
-    <p>When Icechunk 2.0 is released, these datasets will be updated correspondingly, and updated client libraries will be required for access. To be notified of dataset updates, subscribe to the <a href='https://dynamical.org/updates/'>mailing list</a>.</p>
     <ul>
       <li><a href="https://dynamical.org/catalog/ecmwf-aifs-single-forecast/">ECMWF AIFS Single forecast</a> - Weather forecasts from the ECMWF Artificial Intelligence Forecasting System (AIFS) Single model.</li>
     </ul>
@@ -38,9 +31,14 @@ Resources:
     Type: SNS Topic
 DataAtWork:
   Tutorials:
-    - Title: ECMWF AIFS Single forecast python quickstart notebook
-      URL: https://github.com/dynamical-org/notebooks/blob/main/ecmwf-aifs-single-forecast-icechunk.ipynb
-      NotebookURL: https://github.com/dynamical-org/notebooks/blob/main/ecmwf-aifs-single-forecast-icechunk.ipynb
+    - Title: "ECMWF AIFS Single forecast — Quickstart"
+      URL: https://github.com/dynamical-org/notebooks/blob/main/ecmwf-aifs-single-forecast.ipynb
+      NotebookURL: https://github.com/dynamical-org/notebooks/blob/main/ecmwf-aifs-single-forecast.ipynb
+      AuthorName: dynamical.org
+      AuthorURL: https://dynamical.org
+    - Title: "ECMWF AIFS Single forecast — Heating degree days: GFS vs AIFS"
+      URL: https://github.com/dynamical-org/notebooks/blob/main/noaa-gfs+ecmwf-aifs-hdd.ipynb
+      NotebookURL: https://github.com/dynamical-org/notebooks/blob/main/noaa-gfs+ecmwf-aifs-hdd.ipynb
       AuthorName: dynamical.org
       AuthorURL: https://dynamical.org
 ADXCategories:

--- a/datasets/dynamical-ecmwf-ifs-ens.yaml
+++ b/datasets/dynamical-ecmwf-ifs-ens.yaml
@@ -1,23 +1,14 @@
 Name: ECMWF IFS ENS - dynamical.org Icechunk Zarr
 Description: |
-    <p>
-       The Integrated Forecasting System (IFS) is a global forecast model developed 
-       by ECMWF. ENS is an ensemble configuration of IFS, containing 51 ensemble members.
-       IFS consists of a numerical model of the Earth system, which includes
-       an atmospheric model at its heart, coupled with models of other Earth system 
-       components such as the ocean. The data assimilation system combines 
-       the latest weather observations with a recent forecast to obtain the best 
-       possible estimate of the current state of the Earth system.
-      </p>
+    <p>The Integrated Forecasting System (IFS) is a global forecast model developed by ECMWF. ENS is an ensemble configuration of IFS, containing 51 ensemble members. IFS consists of a numerical model of the Earth system, which includes an atmospheric model at its heart, coupled with models of other Earth system components such as the ocean. The data assimilation system combines the latest weather observations with a recent forecast to obtain the best possible estimate of the current state of the Earth system.</p>
     <p>These datasets have been translated to cloud-optimized Icechunk Zarr format by <a href="https://dynamical.org">dynamical.org</a>.</p>
-    <p>When Icechunk 2.0 is released, these datasets will be updated correspondingly, and updated client libraries will be required for access. To be notified of dataset updates, subscribe to the <a href='https://dynamical.org/updates/'>mailing list</a>.</p>
     <ul>
-      <li><a href="https://dynamical.org/catalog/ecmwf-ifs-ens-forecast-15-day-0-25-degree/">ECMWF IFS ENS Forecast, 15 day, 0.25 degree</a> - Ensemble weather forecasts from the ECMWF Integrated Forecasting System (IFS).</li>
+      <li><a href="https://dynamical.org/catalog/ecmwf-ifs-ens-forecast-15-day-0-25-degree/">ECMWF IFS ENS forecast, 15 day, 0.25 degree</a> - Ensemble weather forecasts from the ECMWF Integrated Forecasting System (IFS).</li>
     </ul>
-Documentation: https://dynamical.org/catalog/models/ecmwf-ifs-ens/
+Documentation: https://dynamical.org/catalog/
 Contact: feedback@dynamical.org
 ManagedBy: "[dynamical.org](https://dynamical.org)"
-UpdateFrequency: "ECMWF IFS ENS Forecast, 15 day, 0.25 degree: Forecasts initialized every 24 hours"
+UpdateFrequency: "ECMWF IFS ENS forecast, 15 day, 0.25 degree: Forecasts initialized every 24 hours"
 Tags:
   - aws-pds
   - weather
@@ -40,9 +31,9 @@ Resources:
     Type: SNS Topic
 DataAtWork:
   Tutorials:
-    - Title: ECMWF IFS ENS Forecast, 15 day, 0.25 degree python quickstart notebook
-      URL: https://github.com/dynamical-org/notebooks/blob/main/ecmwf-ifs-ens-forecast-15-day-0-25-degree-icechunk.ipynb
-      NotebookURL: https://github.com/dynamical-org/notebooks/blob/main/ecmwf-ifs-ens-forecast-15-day-0-25-degree-icechunk.ipynb
+    - Title: "ECMWF IFS ENS forecast, 15 day, 0.25 degree — Quickstart"
+      URL: https://github.com/dynamical-org/notebooks/blob/main/ecmwf-ifs-ens-forecast-15-day-0-25-degree.ipynb
+      NotebookURL: https://github.com/dynamical-org/notebooks/blob/main/ecmwf-ifs-ens-forecast-15-day-0-25-degree.ipynb
       AuthorName: dynamical.org
       AuthorURL: https://dynamical.org
 ADXCategories:

--- a/datasets/dynamical-noaa-gefs.yaml
+++ b/datasets/dynamical-noaa-gefs.yaml
@@ -1,18 +1,12 @@
 Name: NOAA GEFS - dynamical.org Icechunk Zarr
 Description: |
-    <p>
-      The Global Ensemble Forecast System (GEFS) is a National Oceanic and
-      Atmospheric Administration (NOAA) National Centers for Environmental
-      Prediction (NCEP) weather forecast model. GEFS creates 31 separate
-      forecasts (ensemble members) to describe the range of forecast uncertainty.
-      </p>
+    <p>The Global Ensemble Forecast System (GEFS) is a National Oceanic and Atmospheric Administration (NOAA) National Centers for Environmental Prediction (NCEP) weather forecast model. GEFS creates 31 separate forecasts (ensemble members) to describe the range of forecast uncertainty.</p>
     <p>These datasets have been translated to cloud-optimized Icechunk Zarr format by <a href="https://dynamical.org">dynamical.org</a>.</p>
-    <p>When Icechunk 2.0 is released, these datasets will be updated correspondingly, and updated client libraries will be required for access. To be notified of dataset updates, subscribe to the <a href='https://dynamical.org/updates/'>mailing list</a>.</p>
     <ul>
       <li><a href="https://dynamical.org/catalog/noaa-gefs-forecast-35-day/">NOAA GEFS forecast, 35 day</a> - Weather forecasts from the Global Ensemble Forecast System (GEFS) operated by NOAA NWS NCEP.</li>
       <li><a href="https://dynamical.org/catalog/noaa-gefs-analysis/">NOAA GEFS analysis</a> - Weather analysis from the Global Ensemble Forecast System (GEFS) operated by NOAA NWS NCEP.</li>
     </ul>
-Documentation: https://dynamical.org/catalog/models/noaa-gefs/
+Documentation: https://dynamical.org/catalog/
 Contact: feedback@dynamical.org
 ManagedBy: "[dynamical.org](https://dynamical.org)"
 UpdateFrequency: "NOAA GEFS forecast, 35 day: Forecasts initialized every 24 hours; NOAA GEFS analysis: 3.0 hours"
@@ -38,14 +32,14 @@ Resources:
     Type: SNS Topic
 DataAtWork:
   Tutorials:
-    - Title: NOAA GEFS forecast, 35 day python quickstart notebook
-      URL: https://github.com/dynamical-org/notebooks/blob/main/noaa-gefs-forecast-35-day-icechunk.ipynb
-      NotebookURL: https://github.com/dynamical-org/notebooks/blob/main/noaa-gefs-forecast-35-day-icechunk.ipynb
+    - Title: "NOAA GEFS forecast, 35 day — Quickstart"
+      URL: https://github.com/dynamical-org/notebooks/blob/main/noaa-gefs-forecast-35-day.ipynb
+      NotebookURL: https://github.com/dynamical-org/notebooks/blob/main/noaa-gefs-forecast-35-day.ipynb
       AuthorName: dynamical.org
       AuthorURL: https://dynamical.org
-    - Title: NOAA GEFS analysis python quickstart notebook
-      URL: https://github.com/dynamical-org/notebooks/blob/main/noaa-gefs-analysis-icechunk.ipynb
-      NotebookURL: https://github.com/dynamical-org/notebooks/blob/main/noaa-gefs-analysis-icechunk.ipynb
+    - Title: "NOAA GEFS analysis — Quickstart"
+      URL: https://github.com/dynamical-org/notebooks/blob/main/noaa-gefs-analysis.ipynb
+      NotebookURL: https://github.com/dynamical-org/notebooks/blob/main/noaa-gefs-analysis.ipynb
       AuthorName: dynamical.org
       AuthorURL: https://dynamical.org
 ADXCategories:

--- a/datasets/dynamical-noaa-gfs.yaml
+++ b/datasets/dynamical-noaa-gfs.yaml
@@ -1,21 +1,12 @@
 Name: NOAA GFS - dynamical.org Icechunk Zarr
 Description: |
-    <p>
-      The Global Forecast System (GFS) is a National Oceanic and Atmospheric
-      Administration (NOAA) National Centers for Environmental Prediction
-      (NCEP) weather forecast model that generates data for dozens of
-      atmospheric and land-soil variables, including temperatures, winds,
-      precipitation, soil moisture, and atmospheric ozone concentration. The
-      system couples four separate models (atmosphere, ocean model, land/soil
-      model, and sea ice) that work together to depict weather conditions.
-      </p>
+    <p>The Global Forecast System (GFS) is a National Oceanic and Atmospheric Administration (NOAA) National Centers for Environmental Prediction (NCEP) weather forecast model that generates data for dozens of atmospheric and land-soil variables, including temperatures, winds, precipitation, soil moisture, and atmospheric ozone concentration. The system couples four separate models (atmosphere, ocean model, land/soil model, and sea ice) that work together to depict weather conditions.</p>
     <p>These datasets have been translated to cloud-optimized Icechunk Zarr format by <a href="https://dynamical.org">dynamical.org</a>.</p>
-    <p>When Icechunk 2.0 is released, these datasets will be updated correspondingly, and updated client libraries will be required for access. To be notified of dataset updates, subscribe to the <a href='https://dynamical.org/updates/'>mailing list</a>.</p>
     <ul>
       <li><a href="https://dynamical.org/catalog/noaa-gfs-analysis/">NOAA GFS analysis</a> - Weather analysis from the Global Forecast System (GFS) operated by NOAA NWS NCEP.</li>
       <li><a href="https://dynamical.org/catalog/noaa-gfs-forecast/">NOAA GFS forecast</a> - Weather forecasts from the Global Forecast System (GFS) operated by NOAA NWS NCEP.</li>
     </ul>
-Documentation: https://dynamical.org/catalog/models/noaa-gfs/
+Documentation: https://dynamical.org/catalog/
 Contact: feedback@dynamical.org
 ManagedBy: "[dynamical.org](https://dynamical.org)"
 UpdateFrequency: "NOAA GFS analysis: 1 hour; NOAA GFS forecast: Forecasts initialized every 6 hours"
@@ -41,14 +32,19 @@ Resources:
     Type: SNS Topic
 DataAtWork:
   Tutorials:
-    - Title: NOAA GFS analysis python quickstart notebook
-      URL: https://github.com/dynamical-org/notebooks/blob/main/noaa-gfs-analysis-icechunk.ipynb
-      NotebookURL: https://github.com/dynamical-org/notebooks/blob/main/noaa-gfs-analysis-icechunk.ipynb
+    - Title: "NOAA GFS analysis — Quickstart"
+      URL: https://github.com/dynamical-org/notebooks/blob/main/noaa-gfs-analysis.ipynb
+      NotebookURL: https://github.com/dynamical-org/notebooks/blob/main/noaa-gfs-analysis.ipynb
       AuthorName: dynamical.org
       AuthorURL: https://dynamical.org
-    - Title: NOAA GFS forecast python quickstart notebook
-      URL: https://github.com/dynamical-org/notebooks/blob/main/noaa-gfs-forecast-icechunk.ipynb
-      NotebookURL: https://github.com/dynamical-org/notebooks/blob/main/noaa-gfs-forecast-icechunk.ipynb
+    - Title: "NOAA GFS forecast — Quickstart"
+      URL: https://github.com/dynamical-org/notebooks/blob/main/noaa-gfs-forecast.ipynb
+      NotebookURL: https://github.com/dynamical-org/notebooks/blob/main/noaa-gfs-forecast.ipynb
+      AuthorName: dynamical.org
+      AuthorURL: https://dynamical.org
+    - Title: "NOAA GFS forecast — Heating degree days: GFS vs AIFS"
+      URL: https://github.com/dynamical-org/notebooks/blob/main/noaa-gfs+ecmwf-aifs-hdd.ipynb
+      NotebookURL: https://github.com/dynamical-org/notebooks/blob/main/noaa-gfs+ecmwf-aifs-hdd.ipynb
       AuthorName: dynamical.org
       AuthorURL: https://dynamical.org
 ADXCategories:

--- a/datasets/dynamical-noaa-hrrr.yaml
+++ b/datasets/dynamical-noaa-hrrr.yaml
@@ -1,20 +1,12 @@
 Name: NOAA HRRR - dynamical.org Icechunk Zarr
 Description: |
-    <p>
-      The High-Resolution Rapid Refresh (HRRR) is a NOAA real-time 3-km resolution,
-      hourly updated, cloud-resolving, convection-allowing atmospheric model,
-      initialized by 3km grids with 3km radar assimilation. Radar data is
-      assimilated in the HRRR every 15 min over a 1-h period adding further
-      detail to that provided by the hourly data assimilation from the 13km
-      radar-enhanced Rapid Refresh.
-      </p>
+    <p>The High-Resolution Rapid Refresh (HRRR) is a NOAA real-time 3-km resolution, hourly updated, cloud-resolving, convection-allowing atmospheric model, initialized by 3km grids with 3km radar assimilation. Radar data is assimilated in the HRRR every 15 min over a 1-h period adding further detail to that provided by the hourly data assimilation from the 13km radar-enhanced Rapid Refresh.</p>
     <p>These datasets have been translated to cloud-optimized Icechunk Zarr format by <a href="https://dynamical.org">dynamical.org</a>.</p>
-    <p>When Icechunk 2.0 is released, these datasets will be updated correspondingly, and updated client libraries will be required for access. To be notified of dataset updates, subscribe to the <a href='https://dynamical.org/updates/'>mailing list</a>.</p>
     <ul>
       <li><a href="https://dynamical.org/catalog/noaa-hrrr-forecast-48-hour/">NOAA HRRR forecast, 48 hour</a> - Weather forecasts from the High-Resolution Rapid Refresh (HRRR) model operated by NOAA NWS NCEP.</li>
       <li><a href="https://dynamical.org/catalog/noaa-hrrr-analysis/">NOAA HRRR analysis</a> - Analysis data from the High-Resolution Rapid Refresh (HRRR) model operated by NOAA NWS NCEP.</li>
     </ul>
-Documentation: https://dynamical.org/catalog/models/noaa-hrrr/
+Documentation: https://dynamical.org/catalog/
 Contact: feedback@dynamical.org
 ManagedBy: "[dynamical.org](https://dynamical.org)"
 UpdateFrequency: "NOAA HRRR forecast, 48 hour: Forecasts initialized every 6 hours; NOAA HRRR analysis: 1 hour"
@@ -40,14 +32,14 @@ Resources:
     Type: SNS Topic
 DataAtWork:
   Tutorials:
-    - Title: NOAA HRRR forecast, 48 hour python quickstart notebook
-      URL: https://github.com/dynamical-org/notebooks/blob/main/noaa-hrrr-forecast-48-hour-icechunk.ipynb
-      NotebookURL: https://github.com/dynamical-org/notebooks/blob/main/noaa-hrrr-forecast-48-hour-icechunk.ipynb
+    - Title: "NOAA HRRR forecast, 48 hour — Quickstart"
+      URL: https://github.com/dynamical-org/notebooks/blob/main/noaa-hrrr-forecast-48-hour.ipynb
+      NotebookURL: https://github.com/dynamical-org/notebooks/blob/main/noaa-hrrr-forecast-48-hour.ipynb
       AuthorName: dynamical.org
       AuthorURL: https://dynamical.org
-    - Title: NOAA HRRR analysis python quickstart notebook
-      URL: https://github.com/dynamical-org/notebooks/blob/main/noaa-hrrr-analysis-icechunk.ipynb
-      NotebookURL: https://github.com/dynamical-org/notebooks/blob/main/noaa-hrrr-analysis-icechunk.ipynb
+    - Title: "NOAA HRRR analysis — Quickstart"
+      URL: https://github.com/dynamical-org/notebooks/blob/main/noaa-hrrr-analysis.ipynb
+      NotebookURL: https://github.com/dynamical-org/notebooks/blob/main/noaa-hrrr-analysis.ipynb
       AuthorName: dynamical.org
       AuthorURL: https://dynamical.org
 ADXCategories:

--- a/datasets/dynamical-noaa-mrms.yaml
+++ b/datasets/dynamical-noaa-mrms.yaml
@@ -1,19 +1,11 @@
 Name: NOAA MRMS - dynamical.org Icechunk Zarr
 Description: |
-    <p>
-      The NOAA Multi-Radar/Multi-Sensor System (MRMS) integrates data from
-      multiple radars and radar networks, surface observations, numerical
-      weather prediction (NWP) models, and climatology to generate seamless,
-      high spatio-temporal resolution mosaics at low latency focused on hail,
-      wind, tornado, quantitative precipitation estimations, convection, icing,
-      and turbulence.
-      </p>
+    <p>The NOAA Multi-Radar/Multi-Sensor System (MRMS) integrates data from multiple radars and radar networks, surface observations, numerical weather prediction (NWP) models, and climatology to generate seamless, high spatio-temporal resolution mosaics at low latency focused on hail, wind, tornado, quantitative precipitation estimations, convection, icing, and turbulence.</p>
     <p>These datasets have been translated to cloud-optimized Icechunk Zarr format by <a href="https://dynamical.org">dynamical.org</a>.</p>
-    <p>When Icechunk 2.0 is released, these datasets will be updated correspondingly, and updated client libraries will be required for access. To be notified of dataset updates, subscribe to the <a href='https://dynamical.org/updates/'>mailing list</a>.</p>
     <ul>
       <li><a href="https://dynamical.org/catalog/noaa-mrms-conus-analysis-hourly/">NOAA MRMS CONUS analysis, hourly</a> - Hourly precipitation analysis from the Multi-Radar Multi-Sensor (MRMS) system operated by NOAA NWS NCEP.</li>
     </ul>
-Documentation: https://dynamical.org/catalog/models/noaa-mrms/
+Documentation: https://dynamical.org/catalog/
 Contact: feedback@dynamical.org
 ManagedBy: "[dynamical.org](https://dynamical.org)"
 UpdateFrequency: "NOAA MRMS CONUS analysis, hourly: 1 hour"
@@ -39,9 +31,9 @@ Resources:
     Type: SNS Topic
 DataAtWork:
   Tutorials:
-    - Title: NOAA MRMS CONUS analysis, hourly python quickstart notebook
-      URL: https://github.com/dynamical-org/notebooks/blob/main/noaa-mrms-conus-analysis-hourly-icechunk.ipynb
-      NotebookURL: https://github.com/dynamical-org/notebooks/blob/main/noaa-mrms-conus-analysis-hourly-icechunk.ipynb
+    - Title: "NOAA MRMS CONUS analysis, hourly — Quickstart"
+      URL: https://github.com/dynamical-org/notebooks/blob/main/noaa-mrms-conus-analysis-hourly.ipynb
+      NotebookURL: https://github.com/dynamical-org/notebooks/blob/main/noaa-mrms-conus-analysis-hourly.ipynb
       AuthorName: dynamical.org
       AuthorURL: https://dynamical.org
 ADXCategories:


### PR DESCRIPTION
- **New comparison tutorial** Adds a new "Heating degree days: GFS vs AIFS" tutorial on both `dynamical-noaa-gfs` and `dynamical-ecmwf-aifs-single`
- **Not "preliminary" anymore** Drops the "When Icechunk 2.0 is released, these datasets will be updated correspondingly, and updated client libraries will be required for access" paragraph. That has been done and they are no longer preliminary
- **Clean up / clarity**
   - Tutorial titles now `{dataset name} — {notebook name}` 
   - Documentation link updated from per-model (`/catalog/models/...`) to the main catalog page, matching dynamical.org catalog URL structure.


---
_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._