### PR TITLE
Update Cryo-EM SPA region to ap-northeast-1 from us-east-1

### DIFF
--- a/datasets/cryoem-spa-workflow-records.yaml
+++ b/datasets/cryoem-spa-workflow-records.yaml
@@ -8,6 +8,7 @@ Tags:
   - structural biology
   - life sciences
   - machine learning
+  - aws-pds
 License: CC0
 Resources:
   - Description: Cryo-EM SPA Workflow Records
@@ -25,7 +26,7 @@ DataAtWork:
   Publications:
     - Title: GoToCloud optimization of cloud computing environment for accelerating cryo-EM structure-based drug design
       URL: https://www.nature.com/articles/s42003-024-07031-6
-      AuthorName: :Toshio Moriya, et al.
+      AuthorName: Toshio Moriya, et al.
       AuthorURL: https://orcid.org/0000-0001-7226-5487
 ADXCategories:
   - Healthcare & Life Sciences Data

--- a/datasets/cryoem-spa-workflow-records.yaml
+++ b/datasets/cryoem-spa-workflow-records.yaml
@@ -12,7 +12,7 @@ License: CC0
 Resources:
   - Description: Cryo-EM SPA Workflow Records
     ARN: arn:aws:s3:::cryoem-spa-workflow-records-public
-    Region: us-east-1
+    Region: ap-northeast-1
     Type: S3 Bucket
     Explore:
     - '[Website](https://sites.google.com/sbrc.jp/gotocloud-doc)'


### PR DESCRIPTION
*Issue #, if available:*

@berylrab @mrkohtzmoriya

Noticed that the bucket was listed as region `us-east-1` on the webpage, but is actually `ap-northeast-1` -- just updating in case users are trying to co-locate the data with compute in the same region.

```
aaronkanzer@Aarons-MacBook-Air ~ % curl -sI https://cryoem-spa-workflow-records-public.s3.amazonaws.com/                              
HTTP/1.1 200 OK
x-amz-id-2: 7KOJHTK5tGxUD0By8yKO3VhfoDyd4cWByzi4ashTiIGA4TAdvamfHoMDoSpA9QV81/6uTuoQKiuwHIuyRbJnmTabjiTRjS8o
x-amz-request-id: WD7Q8HDMV8V45RDZ
Date: Tue, 05 May 2026 11:37:54 GMT
x-amz-bucket-region: ap-northeast-1
x-amz-access-point-alias: false
x-amz-bucket-arn: arn:aws:s3:::cryoem-spa-workflow-records-public
Content-Type: application/xml
Transfer-Encoding: chunked
Server: AmazonS3

```

*Description of changes:*

Changes bucket region to `ap-northeast-1`


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
