### PR TITLE
Fix S3 Bucket ARNs and update contact information, remove dead links

### DIFF
--- a/datasets/nasanex.yaml
+++ b/datasets/nasanex.yaml
@@ -7,8 +7,10 @@ Description: |
   Concentration Pathways (RCPs) [Meinshausen et al. 2011]. The NASA Earth
   Exchange group maintains the NEX-DCP30 (CMIP5), NEX-GDDP (CMIP5), and
   LOCA (CMIP5).
+
+  NOTE: The S3 Bucket location for this dataset changed on 5/6/2026
 Documentation: https://github.com/awslabs/open-data-docs/tree/main/docs/nasa-nex
-Contact: https://www.nasa.gov/nex/team
+Contact: https://www.nasa.gov/nasa-earth-exchange-nex/nex-team/
 UpdateFrequency: Infrequently
 ManagedBy: NASA
 Collabs:
@@ -24,27 +26,19 @@ Tags:
 License: US Government work
 Resources:
   - Description: Downscaled Climate Projections (NEX-DCP30)
-    ARN: arn:aws:s3:::nasanex/NEX-DCP30
+    ARN: arn:aws:s3:::nasa-nex/NEX-DCP30
     Region: us-west-2
     Type: S3 Bucket
   - Description: Global Daily Downscaled Projections (NEX-GDDP)
-    ARN: arn:aws:s3:::nasanex/NEX-GDDP
+    ARN: arn:aws:s3:::nasa-nex/NEX-GDDP
     Region: us-west-2
     Type: S3 Bucket
   - Description: Localized Constructed Analogs (LOCA)
-    ARN: arn:aws:s3:::nasanex/LOCA
+    ARN: arn:aws:s3:::nasa-nex/LOCA
     Region: us-west-2
     Type: S3 Bucket
 DataAtWork:
   Tutorials:
-    - Title: Accessing and plotting NASA-NEX data, from GEOSChem-on-cloud tutorial.
-      URL: https://cloud-gc.readthedocs.io/en/latest/chapter02_beginner-tutorial/use-s3.html#access-nasa-nex-data-in-s3-optional-but-recommended
-      AuthorName: Jiawei Zhuang
-      AuthorURL: https://github.com/JiaweiZhuang
-    - Title: Sample Python code to analyze NASA-NEX data.
-      URL: https://cloud-gc.readthedocs.io/en/latest/chapter06_appendix/plot_NASANEX.html
-      AuthorName: Jiawei Zhuang
-      AuthorURL: https://github.com/JiaweiZhuang
   Tools & Applications:
   Publications:
     - Title: Downscaled Climate Projections Suitable for Resource Management, Eos Trans. AGU, 94(37), 321.


### PR DESCRIPTION
Updated S3 Bucket ARNs and corrected contact link for NASA Earth Exchange dataset.

Also removed 2 dead links for old tutorials that no longer exist.

This dataset moved from s3://nasanex to s3://nasa-nex on 5/6/2026

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
