### PR TITLE
removed extra colons in ARN

### DIFF
--- a/datasets/cmas-data-warehouse.yaml
+++ b/datasets/cmas-data-warehouse.yaml
@@ -68,19 +68,19 @@ Resources:
     - '[Browse Bucket](https://epa-equates-v1.s3.amazonaws.com/index.html)'
     - '[EPA CMAQ 2019 3D Gridded and Column data from EQUATES Project](https://aws.amazon.com/marketplace/pp/prodview-kziefcewnxcxe?sr=0-5&ref_=beagle&applicationId=AWSMPContessa)'
   - Description: CMAQ 2023 12US4 CRACMM3 Modeling Platform
-    ARN: arn:aws:s3::::::cmaq-12us4-cracmm3-modeling-platform-2023
+    ARN: arn:aws:s3:::cmaq-12us4-cracmm3-modeling-platform-2023
     Region: us-east-1
     Type: S3 Bucket
     Explore:
     - '[Browse Bucket](https://cmaq-12us4-cracmm3-modeling-platform-2023.s3.amazonaws.com/index.html)'
   - Description: CMAQ Model Versions 5.5 CRACMM2 Input Data (2022r1) -- 12/22/2021 - 12/31/2022 12km CONUS
-    ARN:  arn:aws:s3::::::cmaq-12us1-cracmm2-modeling-platform-2022
+    ARN:  arn:aws:s3:::cmaq-12us1-cracmm2-modeling-platform-2022
     Region: us-east-1
     Type: S3 Bucket
     Explore:
     - '[Browse Bucket](https://cmaq-12us1-cracmm2-modeling-platform-2022.s3.amazonaws.com/index.html)'
   - Description: CMAQ Model Versions 5.5 CRACMM1-2 Input Data -- 12/22/2019 - 12/31/2020 12km CONUS
-    ARN:  arn:aws:s3::::::cmaq-12us1-cracmm1-modeling-platform-2020
+    ARN:  arn:aws:s3:::cmaq-12us1-cracmm1-modeling-platform-2020
     Region: us-east-1
     Type: S3 Bucket
     Explore:


### PR DESCRIPTION
Fixed an issue of having too many colons in the ARN that caused an issue in the command to list files in the bucket under AWS CLI.

Amazon Resource Name (ARN)
    arn:aws:s3::::::cmaq-12us4-cracmm3-modeling-platform-2023
                       ^^
                     should only be 3 colons

AWS Region
    us-east-1
[AWS CLI](https://aws.amazon.com/cli/) Access (No AWS account required)
    aws s3 ls --no-sign-request s3:///

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
