### PR TITLE
Include Scigantic tutorial for OME-Zarr Open SciVis page

### DIFF
--- a/datasets/ome-zarr-open-scivis.yaml
+++ b/datasets/ome-zarr-open-scivis.yaml
@@ -29,6 +29,10 @@ DataAtWork:
       URL: https://github.com/InsightSoftwareConsortium/OMEZarrOpenSciVisDatasets?tab=readme-ov-file#usage
       AuthorName: Matt McCormick
       AuthorURL: https://github.com/thewtex
+    - Title: Explore OME-Zarr Open SciVis Datasets in a Browser-Based Notebook on Scigantic
+      URL: https://scigantic.com/archive/c7122f2c-4639-5864-b063-61af7d973461/sample
+      AuthorName: Scigantic
+      AuthorURL: https://scigantic.com/
   Tools & Applications:
     - Title: A list of tools and libraries with OME-Zarr support
       URL: https://ngff.openmicroscopy.org/tools/index.html

--- a/datasets/ome-zarr-open-scivis.yaml
+++ b/datasets/ome-zarr-open-scivis.yaml
@@ -51,4 +51,3 @@ DataAtWork:
 DeprecatedNotice:
 ADXCategories:
   - Healthcare & Life Sciences Data
-  - Manufacturing Data


### PR DESCRIPTION
Include Scigantic tutorial for OME-Zarr Open SciVis page

Cc @thewtex, will send over a demo video soon, but adding this mini-sample notebook as well. I've added `ngff-zarr` to the Neuroscience base-image on Scigantic -- wasn't able to get `itkwidgets` however since it had a dependency conflict with others in the image, such as pydantic and zarr versioning

As an aside, thanks @berylrab for letting me add these tutorials!
