### PR TITLE
Update A2D2 contact, documentation, and managed-by fields

### DIFF
--- a/datasets/aev-a2d2.yaml
+++ b/datasets/aev-a2d2.yaml
@@ -7,9 +7,9 @@ Description:
         three sequences. We hope this dataset will further facilitate
         active research and development in AI, computer vision, and
         robotics for autonomous driving.
-Contact: aevdrivingdataset@audi.de
-Documentation: http://a2d2.audi
-ManagedBy: "[Audi AG](http://a2d2.audi/)"
+Contact: a2d2-dataset@googlegroups.com
+Documentation: https://a2d2-dataset.github.io
+ManagedBy: "[Amazon](https://www.amazon.com/)"
 UpdateFrequency:
         The dataset may be updated with additional or corrected data
         on a need-to-update basis.


### PR DESCRIPTION
## Summary

- Contact updated to public Google Group (`a2d2-dataset@googlegroups.com`)
- Documentation URL updated to new GitHub Pages site (https://a2d2-dataset.github.io)
- ManagedBy updated to Amazon