### PR TITLE
add 2025 CMAQ Modeling Data Platform

### DIFF
--- a/datasets/cmas-data-warehouse.yaml
+++ b/datasets/cmas-data-warehouse.yaml
@@ -100,6 +100,16 @@ Resources:
     Explore:
     - '[Browse Bucket](https://epa-equates-v1.s3.amazonaws.com/index.html)'
     - '[EPA CMAQ 2019 3D Gridded and Column data from EQUATES Project](https://aws.amazon.com/marketplace/pp/prodview-kziefcewnxcxe?sr=0-5&ref_=beagle&applicationId=AWSMPContessa)'
+  - Description: CMAQ 2025 12US1 CRACMM2 CAP-HAP Modeling Platform 
+    ARN: arn:aws:s3:::cmaq-12us1-cracmm2-cap-hap-modeling-platform-2025
+    Region: us-east-1
+    Type: S3 Bucket
+    Explore:
+    - '[Browse Bucket](https://cmaq-12us1-cracmm2-cap-hap-modeling-platform-2025.s3.amazonaws.com/index.html)'
+  - Description: Notifications for new data in CMAQ 2025 12US1 CRACMM2 CAP-HAP Modeling Platform
+    ARN: arn:aws:sns:us-east-1:703786580975:cmaq-12us1-cracmm2-cap-hap-modeling-platform-2025-object_created
+    Region: us-east-1
+    Type: SNS Topic
   - Description: CMAQ 2023 12US4 CRACMM3 Modeling Platform
     ARN: arn:aws:s3:::cmaq-12us4-cracmm3-modeling-platform-2023
     Region: us-east-1


### PR DESCRIPTION
*Description of changes:*
Adding dataset for EPA titled CMAQ Model Version 5.5 CRACMM2 CAP-HAP Input Data – 12/01/2024 - 12/31/2025 12km CONUS.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
