### PR TITLE
Update OceanOmics resource links

### DIFF
--- a/datasets/oceanomics.yaml
+++ b/datasets/oceanomics.yaml
@@ -14,7 +14,7 @@ Tags:
   - life sciences
 License: "CC-BY 4.0 https://creativecommons.org/licenses/by/4.0/deed.en"
 Resources:
-  - Description: https://github.com/MinderooFoundation/OceanOmics-OpenData/blob/master/aws-public-data.md
+  - Description: https://github.com/Minderoo-OceanOmics-Centre-UWA/OceanOmics-OpenData/blob/master/aws-public-data.md
     ARN: arn:aws:s3:::minderoo-oceanomics
     Region: us-west-2
     Type: S3 Bucket
@@ -22,6 +22,6 @@ DataAtWork:
   Tutorials:
   - AuthorName: Philipp Bayer
     Title: Case-studies on using OceanOmics genomes and eDNA data 
-    URL: https://github.com/MinderooFoundation/OceanOmics-OpenData/blob/master/tutorial.md
+    URL: https://github.com/Minderoo-OceanOmics-Centre-UWA/OceanOmics-OpenData/blob/master/tutorial.md
   Tools & Applications:
   Publications:


### PR DESCRIPTION
Updated the OceanOmics dataset metadata to point to the current OceanOmics Centre GitHub documentation repository.

Changes include:
- Updated the resource documentation URL to the new OceanOmics Centre repository.
- Updated the tutorial URL to the new OceanOmics Centre repository.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
