### PR TITLE
Update A2D2 ManagedBy to dataset maintainers

### DIFF
--- a/datasets/aev-a2d2.yaml
+++ b/datasets/aev-a2d2.yaml
@@ -9,7 +9,7 @@ Description:
         robotics for autonomous driving.
 Contact: a2d2-dataset@googlegroups.com
 Documentation: https://a2d2-dataset.github.io
-ManagedBy: "[Amazon](https://www.amazon.com/)"
+ManagedBy: Mentar Mahmudi, Jakob Geyer, Lorenz Hauswald
 UpdateFrequency:
         The dataset may be updated with additional or corrected data
         on a need-to-update basis.


### PR DESCRIPTION
Updates the ManagedBy field for the A2D2 dataset entry to list the dataset maintainers: Mentar Mahmudi, Jakob Geyer, Lorenz Hauswald. Follow-up to #3218.