### PR TITLE
Add UniProt release 2026_02

### DIFF
--- a/datasets/uniprot.yaml
+++ b/datasets/uniprot.yaml
@@ -18,6 +18,10 @@ Tags:
   - SPARQL
 License: http://creativecommons.org/licenses/by/4.0/ 
 Resources: 
+  - Description: UniProt 2026_02 
+    ARN: arn:aws:s3:::aws-open-data-uniprot-rdf/2026-02/ 
+    Region: eu-west-3 
+    Type: S3 Bucket 
   - Description: UniProt 2026_01 
     ARN: arn:aws:s3:::aws-open-data-uniprot-rdf/2026-01/ 
     Region: eu-west-3 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

UniProt RDF release 2026_02, now in compressed ntriples format for easier use with Amazon Neptune Analytics.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
