### PR TITLE
Add Scigantic tutorial to CRCNS dataset, resolve region to us-west-2

### DIFF
--- a/datasets/crcnsarchive.yaml
+++ b/datasets/crcnsarchive.yaml
@@ -29,7 +29,7 @@ License: Most contributors of individual datasets request that the dataset and p
 Resources:
   - Description: All datasets
     ARN: arn:aws:s3:::crcnsarchive
-    Region: us-east-2
+    Region: us-west-2
     Type: S3 Bucket
 DataAtWork:
   Tutorials:
@@ -37,6 +37,10 @@ DataAtWork:
       URL: https://github.com/jeffteeters/open-data-examples/blob/main/crcnsarchive/get-to-know-a-dataset.ipynb
       AuthorName: Jeff Teeters
       AuthorURL: https://redwood.berkeley.edu/people/jeff-teeters/
+    - Title: Exploring CRCNS Datasets in a Browser-Based Notebook on Scigantic
+      URL: https://scigantic.com/archive/a852e22f-0786-5b8c-b401-20ef8aafc99f/sample
+      AuthorName: Scigantic
+      AuthorURL: https://scigantic.com
   Publications:
     - Title: Data Sharing for Computational Neuroscience
       URL: https://link.springer.com/article/10.1007/s12021-008-9009-y


### PR DESCRIPTION
*Issue #, if available:*

@berylrab @jeffteeters (Jeff, nice to meet you! 😄 )

Adding a tutorial from Scigantic to CRCNS's page.

Also noticed that the bucket was listed as region us-east-2 on the webpage, but is actually us-west-2 -- just updating in case users are trying to co-locate the data with compute in the same region.

```
aaronkanzer@Aarons-MacBook-Air ~ % curl -sI https://crcnsarchive.s3.amazonaws.com/ | grep -i x-amz-bucket-region
x-amz-bucket-region: us-west-2
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
