### PR TITLE
Add US and Canadian Payroll, Sales and Property Tax Reference Data (2026)

### DIFF
--- a/datasets/statetakehome-open-data.yaml
+++ b/datasets/statetakehome-open-data.yaml
@@ -1,0 +1,61 @@
+Name: US and Canadian Payroll, Sales and Property Tax Reference Data (2026)
+Description: |
+  A machine-readable reference of 2026 statutory tax parameters for the United
+  States and Canada, compiled from primary sources: IRS Publication 15-T and
+  Rev. Proc. 2025-32, the 50 state Departments of Revenue plus the District of
+  Columbia, the Social Security Administration wage base, U.S. Census Bureau
+  American Community Survey 5-year estimates, the Canada Revenue Agency and the
+  13 provincial and territorial authorities.
+  <br/>
+  <br/>
+  The collection covers net take-home pay for 51 US jurisdictions across 11
+  income levels and 2 filing statuses (1,122 observations); full state income
+  tax brackets, standard deductions and personal exemptions; federal brackets,
+  FICA thresholds and the 2025 OBBBA provisions; state and combined sales tax
+  rates; effective property tax rates for 51 states and 3,125 counties; vehicle
+  property tax by state; an hourly-to-annual salary reference table; and the
+  Canadian equivalents covering provincial net pay, GST/HST/PST, minimum wages
+  and TFSA/RRSP limits.
+  <br/>
+  <br/>
+  Every file is plain UTF-8 CSV with a documented header row, versioned by tax
+  year, and mirrored under persistent identifiers (DOI) for citation.
+Documentation: https://statetakehome.com/data
+Contact: For questions about data content, sources or methodology, see the [methodology page](https://statetakehome.com/methodology) or email contact@statetakehome.com
+ManagedBy: "[StateTakeHome](https://statetakehome.com/)"
+UpdateFrequency: Annually, following the publication of federal, state and provincial tax parameters for the coming tax year
+Tags:
+  - aws-pds
+  - economics
+  - statistics
+  - socioeconomic
+  - census
+  - housing
+  - canada
+License: |
+  Creative Commons Attribution 4.0 International (CC BY 4.0).
+  Attribution requested as: StateTakeHome, "US and Canadian Payroll, Sales and
+  Property Tax Reference Data (2026)", https://statetakehome.com/data
+Resources:
+  - Description: Tax reference data in CSV format, covering the United States (us/) and Canada (ca/)
+    ARN: arn:aws:s3:::statetakehome-open-data
+    Region: us-east-1
+    Type: S3 Bucket
+    Explore:
+    - '[Browse bucket](https://statetakehome-open-data.s3.amazonaws.com/)'
+DataAtWork:
+  Tutorials:
+  Tools & Applications:
+    - Title: us-take-home-data - Rust crate for querying the take-home pay dataset
+      URL: https://docs.rs/us-take-home-data
+      AuthorName: StateTakeHome
+    - Title: StateTakeHome open data documentation
+      URL: https://statetakehome-docs.readthedocs.io/en/latest/
+      AuthorName: StateTakeHome
+  Publications:
+    - Title: "US Take-Home Pay by State, 2026: Net Pay After Federal, State and FICA Taxes"
+      URL: https://doi.org/10.7910/DVN/MY6XD3
+      AuthorName: Tresor Kaya
+    - Title: "US Property Taxes by State and County, 2026: Effective Rates, Median Home Values and Median Taxes Paid"
+      URL: https://doi.org/10.7910/DVN/JDRIUL
+      AuthorName: Tresor Kaya


### PR DESCRIPTION
## Summary

Adds a new dataset entry for a machine-readable reference of 2026 statutory tax parameters for the United States and Canada.

**Bucket:** `arn:aws:s3:::statetakehome-open-data` (us-east-1, publicly readable, no requester-pays)
**Browse:** https://statetakehome-open-data.s3.amazonaws.com/

## What the data contains

15 objects (~330 KB), plain UTF-8 CSV with documented header rows:

**`us/`**
- Net take-home pay for 51 jurisdictions × 11 income levels × 2 filing statuses (1,122 rows)
- A 51-row ranking at the $100,000 single benchmark
- State income tax brackets, standard deductions and personal exemptions
- Federal brackets, FICA thresholds and 2025 OBBBA provisions
- State and combined sales tax rates
- Effective property tax rates for 51 states and 3,125 counties
- Vehicle property tax by state
- Hourly-to-annual salary reference table

**`ca/`**
- Provincial net pay, GST/HST/PST, minimum wages, TFSA and RRSP limits

## Sources

IRS Publication 15-T and Rev. Proc. 2025-32; the 50 state Departments of Revenue plus the District of Columbia; SSA wage base; U.S. Census Bureau ACS 5-year estimates; Tax Foundation; Canada Revenue Agency and the 13 provincial and territorial authorities. Every figure carries an explicit 2026 vintage.

## Documentation and persistent identifiers

- Data dictionary: https://statetakehome.com/data
- Methodology: https://statetakehome.com/methodology
- Full documentation: https://statetakehome-docs.readthedocs.io/en/latest/
- DOI (take-home pay): https://doi.org/10.7910/DVN/MY6XD3
- DOI (property taxes): https://doi.org/10.7910/DVN/JDRIUL
- Rust client library: https://docs.rs/us-take-home-data

## License

CC BY 4.0, with attribution requested as "StateTakeHome, https://statetakehome.com/data".

## Checklist

- [x] Tags validated against `tags.yaml`
- [x] `aws-pds` tag included
- [x] Bucket is publicly readable and anonymously listable (verified with unauthenticated requests)
- [x] YAML parses cleanly
