### PR TITLE
Add dataset: NovoMCP Open Corpus (lite) — 122M PubChem compounds

### DIFF
--- a/datasets/novomcp-open-corpus-lite.yaml
+++ b/datasets/novomcp-open-corpus-lite.yaml
@@ -1,0 +1,37 @@
+Name: NovoMCP Open Corpus (lite)
+Description: >-
+  122,454,458 PubChem compounds with RDKit physicochemical descriptors,
+  ~30 ADMET/toxicity predictions (NovoMCP models, trained on the public
+  Therapeutics Data Commons benchmark), and PAINS structural-alert flags. One row
+  per PubChem CID, stored as Apache Parquet (Snappy) for direct in-place querying
+  (Athena, DuckDB, PyArrow, pandas). Computed properties and model predictions for
+  research use — not experimental measurements or regulatory determinations.
+Documentation: https://github.com/NovoMCP/open-data-examples/tree/main/novomcp-open-corpus-lite
+Contact: https://github.com/NovoMCP/novomcp/issues
+ManagedBy: "[NovoMCP](https://github.com/NovoMCP)"
+UpdateFrequency: Static release; refreshed periodically as models improve (versioned).
+Tags:
+  - chemistry
+  - life sciences
+  - machine learning
+License: CC-BY-4.0 (https://creativecommons.org/licenses/by/4.0/)
+Resources:
+  - Description: Parquet shards (1409 files, 27.4 GB, 122,454,458 rows x 59 columns)
+    ARN: arn:aws:s3:::novomcp-open-corpus/novomcp-open-corpus-lite/
+    Region: us-east-1
+    Type: S3 Bucket
+DataAtWork:
+  Tutorials:
+    - Title: "Get To Know A Dataset: NovoMCP Open Corpus (lite)"
+      URL: https://github.com/NovoMCP/open-data-examples/blob/main/novomcp-open-corpus-lite/get-to-know-a-dataset.ipynb
+      AuthorName: Ari Harrison, NovoMCP
+      AuthorURL: https://github.com/NovoMCP
+  Tools & Applications:
+    - Title: NovoMCP engine (open computational-chemistry engine that produced this corpus)
+      URL: https://github.com/NovoMCP/novomcp
+    - Title: Kaggle mirror
+      URL: https://www.kaggle.com/datasets/novomcp/novomcp-corpus-lite-122m
+  Publications:
+    - Title: "NovoMCP Open Corpus (lite): 122M compounds (Zenodo record, DOI)"
+      URL: https://doi.org/10.5281/zenodo.21710895
+      AuthorName: Ari Harrison, NovoMCP

--- a/datasets/novomcp-open-corpus-lite.yaml
+++ b/datasets/novomcp-open-corpus-lite.yaml
@@ -18,7 +18,7 @@ License: CC-BY-4.0 (https://creativecommons.org/licenses/by/4.0/)
 Resources:
   - Description: Parquet shards (1409 files, 27.4 GB, 122,454,458 rows x 59 columns)
     ARN: arn:aws:s3:::novomcp-open-corpus/novomcp-open-corpus-lite/
-    Region: us-east-1
+    Region: us-east-2
     Type: S3 Bucket
 DataAtWork:
   Tutorials:

--- a/datasets/novomcp-open-corpus-lite.yaml
+++ b/datasets/novomcp-open-corpus-lite.yaml
@@ -37,8 +37,10 @@ DataAtWork:
   Tools & Applications:
     - Title: NovoMCP engine (open computational-chemistry engine that produced this corpus)
       URL: https://github.com/NovoMCP/novomcp
+      AuthorName: Ari Harrison, NovoMCP
     - Title: Kaggle mirror
       URL: https://www.kaggle.com/datasets/novomcp/novomcp-corpus-lite-122m
+      AuthorName: Ari Harrison, NovoMCP
   Publications:
     - Title: "NovoMCP Open Corpus (lite): 122M compounds (Zenodo record, DOI)"
       URL: https://doi.org/10.5281/zenodo.21710895

--- a/datasets/novomcp-open-corpus-lite.yaml
+++ b/datasets/novomcp-open-corpus-lite.yaml
@@ -4,8 +4,12 @@ Description: >-
   ~30 ADMET/toxicity predictions (NovoMCP models, trained on the public
   Therapeutics Data Commons benchmark), and PAINS structural-alert flags. One row
   per PubChem CID, stored as Apache Parquet (Snappy) for direct in-place querying
-  (Athena, DuckDB, PyArrow, pandas). Computed properties and model predictions for
-  research use — not experimental measurements or regulatory determinations.
+  (Athena, DuckDB, PyArrow, pandas). An analysis-ready cheminformatics substrate
+  for drug discovery: virtual screening, drug-likeness (QED) filtering, similarity
+  search, chemical-space exploration, and training ADMET models at scale — so you
+  don't recompute descriptors and property predictions across all of PubChem
+  yourself. Computed properties and model predictions for research use — not
+  experimental measurements or regulatory determinations.
 Documentation: https://github.com/NovoMCP/open-data-examples/tree/main/novomcp-open-corpus-lite
 Contact: https://github.com/NovoMCP/novomcp/issues
 ManagedBy: "[NovoMCP](https://github.com/NovoMCP)"
@@ -14,6 +18,10 @@ Tags:
   - chemistry
   - life sciences
   - machine learning
+  - drug discovery
+  - molecule
+  - pharmaceutical
+  - parquet
 License: CC-BY-4.0 (https://creativecommons.org/licenses/by/4.0/)
 Resources:
   - Description: Parquet shards (1409 files, 27.4 GB, 122,454,458 rows x 59 columns)


### PR DESCRIPTION
Entry for the **NovoMCP Open Corpus (lite)** — a program-sponsored dataset (AWS Open Data Sponsorship Program).

**Dataset:** 122,454,458 PubChem compounds with RDKit physicochemical descriptors, ~30 ADMET/toxicity predictions (NovoMCP models trained on the public Therapeutics Data Commons benchmark), and PAINS structural-alert flags. Apache Parquet (Snappy), one row per PubChem CID, CC-BY-4.0. Also on [Kaggle](https://www.kaggle.com/datasets/novomcp/novomcp-corpus-lite-122m) and [Zenodo (DOI 10.5281/zenodo.21710895)](https://doi.org/10.5281/zenodo.21710895).

**Status — live & ready for review.** The sponsored account is linked to the program billing Organization, and the data is public at `s3://novomcp-open-corpus/novomcp-open-corpus-lite/` (**us-east-2**, 1,409 Parquet shards, 27.4 GB) — anonymous read verified (HTTP 200, no credentials). Documentation (data dictionary) and the "Get To Know A Dataset" tutorial notebook are published at https://github.com/NovoMCP/open-data-examples/tree/main/novomcp-open-corpus-lite