### PR TITLE
Update dynamical.org noaa-hrrr

### DIFF
--- a/datasets/dynamical-noaa-hrrr.yaml
+++ b/datasets/dynamical-noaa-hrrr.yaml
@@ -1,17 +1,17 @@
 Name: NOAA HRRR - dynamical.org Icechunk Zarr
 Description: |
     The High-Resolution Rapid Refresh (HRRR) is a NOAA real-time 3-km resolution, hourly updated, cloud-resolving, convection-allowing atmospheric model, initialized by 3km grids with 3km radar assimilation. Radar data is assimilated in the HRRR every 15 min over a 1-h period adding further detail to that provided by the hourly data assimilation from the 13km radar-enhanced Rapid Refresh.
-    <br><br>
-    These datasets have been translated to cloud-optimized Icechunk Zarr format by [dynamical.org]("https://dynamical.org").
-    
-      - [NOAA HRRR forecast, 48 hour](https://dynamical.org/catalog/noaa-hrrr-forecast-48-hour/) - Weather forecasts from the High-Resolution Rapid Refresh (HRRR) model operated by NOAA NWS NCEP.
-      - [NOAA HRRR forecast, 48 hour, virtual](https://dynamical.org/catalog/noaa-hrrr-forecast-48-hour-virtual/) - Weather forecasts from the High-Resolution Rapid Refresh (HRRR) model operated by NOAA NWS NCEP.
-      - [NOAA HRRR analysis](https://dynamical.org/catalog/noaa-hrrr-analysis/) - Analysis data from the High-Resolution Rapid Refresh (HRRR) model operated by NOAA NWS NCEP.
-    
+
+    These datasets have been translated to cloud-optimized Icechunk Zarr format by [dynamical.org](https://dynamical.org).
+
+    - [NOAA HRRR forecast, 18 hour, virtual](https://dynamical.org/catalog/noaa-hrrr-forecast-18-hour-virtual/) - Weather forecasts from the High-Resolution Rapid Refresh (HRRR) model operated by NOAA NWS NCEP.
+    - [NOAA HRRR forecast, 48 hour](https://dynamical.org/catalog/noaa-hrrr-forecast-48-hour/) - Weather forecasts from the High-Resolution Rapid Refresh (HRRR) model operated by NOAA NWS NCEP.
+    - [NOAA HRRR forecast, 48 hour, virtual](https://dynamical.org/catalog/noaa-hrrr-forecast-48-hour-virtual/) - Weather forecasts from the High-Resolution Rapid Refresh (HRRR) model operated by NOAA NWS NCEP.
+    - [NOAA HRRR analysis](https://dynamical.org/catalog/noaa-hrrr-analysis/) - Analysis data from the High-Resolution Rapid Refresh (HRRR) model operated by NOAA NWS NCEP.
 Documentation: https://dynamical.org/catalog/
 Contact: feedback@dynamical.org
 ManagedBy: "[dynamical.org](https://dynamical.org)"
-UpdateFrequency: "NOAA HRRR forecast, 48 hour: Forecasts initialized every 6 hours; NOAA HRRR forecast, 48 hour, virtual: Forecasts initialized every 6 hours; NOAA HRRR analysis: 1 hour"
+UpdateFrequency: "NOAA HRRR forecast, 18 hour, virtual: Forecasts initialized every hour; NOAA HRRR forecast, 48 hour: Forecasts initialized every 6 hours; NOAA HRRR forecast, 48 hour, virtual: Forecasts initialized every 6 hours; NOAA HRRR analysis: 1 hour"
 Tags:
   - aws-pds
   - weather
@@ -34,6 +34,11 @@ Resources:
     Type: SNS Topic
 DataAtWork:
   Tutorials:
+    - Title: "NOAA HRRR forecast, 18 hour, virtual — Quickstart"
+      URL: https://github.com/dynamical-org/notebooks/blob/main/noaa-hrrr-forecast-18-hour-virtual.ipynb
+      NotebookURL: https://github.com/dynamical-org/notebooks/blob/main/noaa-hrrr-forecast-18-hour-virtual.ipynb
+      AuthorName: dynamical.org
+      AuthorURL: https://dynamical.org
     - Title: "NOAA HRRR forecast, 48 hour — Quickstart"
       URL: https://github.com/dynamical-org/notebooks/blob/main/noaa-hrrr-forecast-48-hour.ipynb
       NotebookURL: https://github.com/dynamical-org/notebooks/blob/main/noaa-hrrr-forecast-48-hour.ipynb


### PR DESCRIPTION
Update the dynamical.org noaa-hrrr dataset entry to include a virtualized Icechunk Zarr for the 18 hour NOAA HRRR product.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.