### PR TITLE
Add umbra-py under Umbra SAR Open Data tools and tutorials

### DIFF
--- a/datasets/umbra-open-data.yaml
+++ b/datasets/umbra-open-data.yaml
@@ -22,3 +22,23 @@ Resources:
     RequesterPays: False
     Explore:
     - '[Browse Bucket](http://umbra-open-data-catalog.s3-website.us-west-2.amazonaws.com/)'
+DataAtWork:
+  Tools & Applications:
+    - Title: umbra-py — Python toolkit to search, preview, load, and convert Umbra open SAR data
+      URL: https://pypi.org/project/umbra-py/
+      AuthorName: umbra-py contributors
+      AuthorURL: https://github.com/reesehammer/umbra-py
+    - Title: umbra-py documentation and interactive catalog showcase
+      URL: https://umbra-py.space/
+      AuthorName: umbra-py contributors
+      AuthorURL: https://github.com/reesehammer/umbra-py
+  Tutorials:
+    - Title: umbra-py quickstart (search, preview, and load a scene)
+      URL: https://umbra-py.space/quickstart/
+      AuthorName: umbra-py contributors
+      AuthorURL: https://github.com/reesehammer/umbra-py
+    - Title: umbra-py example notebooks (search, load, change detection, chips, SICD)
+      URL: https://github.com/reesehammer/umbra-py/tree/main/examples
+      NotebookURL: https://github.com/reesehammer/umbra-py/blob/main/examples/01_hello_umbra.ipynb
+      AuthorName: umbra-py contributors
+      AuthorURL: https://github.com/reesehammer/umbra-py


### PR DESCRIPTION
## Summary

Adds a **DataAtWork** section to [`datasets/umbra-open-data.yaml`](https://github.com/awslabs/open-data-registry/blob/main/datasets/umbra-open-data.yaml). The Umbra Open Data page currently has no Tools or Tutorials; this PR only appends community usage examples.

We are **not** the dataset owner (Umbra / `help@umbra.space`). No changes to Name, Description, ManagedBy, Contact, License, or the S3 resource.

**umbra-py** is an unofficial Apache-2.0 Python toolkit for this bucket. Umbra publishes a static STAC tree with no search API; the library is the search/preview/load layer (`pip install umbra-py`). It is not affiliated with Umbra Lab, Inc.

### Tools & Applications
- [umbra-py on PyPI](https://pypi.org/project/umbra-py/) — search, preview, load, convert
- [Documentation and catalog showcase](https://umbra-py.space/)

### Tutorials
- [Quickstart](https://umbra-py.space/quickstart/)
- [Example notebooks](https://github.com/reesehammer/umbra-py/tree/main/examples) (with `01_hello_umbra.ipynb` as `NotebookURL`)

Source: https://github.com/reesehammer/umbra-py