### PR TITLE
Add Active Visual Semantics (AVS) dataset

### DIFF
--- a/datasets/avs.yaml
+++ b/datasets/avs.yaml
@@ -1,0 +1,81 @@
+Name: Active Visual Semantics
+
+Description: >
+  The Active Visual Semantics (AVS) Dataset is a multimodal neuroimaging dataset combining
+  magnetoencephalography (MEG), eye-tracking, and structural MRI, recorded from 5 participants
+  (sub-01-sub-05) as they actively explored 4,080 natural scenes (subsampled from the Natural
+  Scenes Dataset, NSD) across 10 recording sessions each, yielding more than 200,000 fixation
+  epochs in total. Unlike neuroimaging datasets that rely on passive viewing with enforced
+  central fixation, AVS captures brain activity during active, self-directed scene exploration,
+  including natural saccades and fixations. A semantic scene-captioning task on 25% of trials
+  links gaze behaviour to scene understanding and memory. For each session we provide
+  eye-movement-locked MEG epochs (fixation- and saccade-locked; epochs for other events such as
+  scene onset can be easily recomputed), raw and preprocessed eye-tracking data, per-fixation
+  object category labels, human ratings of whether fixation targets were mentioned in
+  participants' scene captions, pupil dynamics, and defaced structural MRI scans. Individualised
+  head stabilisation casts, together with the structural scans, enable precise source
+  reconstruction at the single-participant level across sessions. Source-reconstruction
+  derivatives (FreeSurfer cortical surfaces, BEM models, forward solutions) are provided for
+  every subject and are directly usable as an MNE-Python SUBJECTS_DIR. The dataset is
+  accompanied by the open-source pyAVS Python package for loading, preprocessing, and analysis.
+
+Documentation: https://kietzmannlab.uni-osnabrueck.de/avs/
+# The pyAVS Sphinx docs site — dataset structure, methods pages, tutorials, full API reference.
+
+Contact: Philip Sulewski (phsulewski@gmail.com)
+
+ManagedBy: "[Kietzmann Lab](https://kietzmannlab.uni-osnabrueck.de) at Universität Osnabrück"
+
+UpdateFrequency: >
+  Initial release as a single batch. Select additional derivative artifacts (e.g.
+  caption-to-object matching tables, scene-sampling metadata) are planned for future addition;
+  no fixed update schedule otherwise.
+
+Tags:
+  - aws-pds
+  - neuroscience
+  - neuroimaging
+  - machine learning
+  - electrophysiology
+  - magnetic resonance imaging
+  - brain images
+  - computer vision
+  - life sciences
+  - natural language processing
+
+License: "[Creative Commons Attribution 4.0 International (CC BY 4.0)](https://creativecommons.org/licenses/by/4.0/)"
+
+Resources:
+  - Description: MEG, eye-tracking, MRI/FreeSurfer derivatives, and behavioural data from the
+      Active Visual Semantics (AVS) dataset.
+    ARN: arn:aws:s3:::kietzmannlab-avs
+    Region: us-west-2
+    Type: S3 Bucket
+    # Bucket currently holds only a partial demo subset (sub-01, 4/10 sessions, ~50 GiB) for
+    # ODP-review/tutorial purposes. The full ~712 GiB release upload is pending completion of
+    # AWS Open Data Sponsorship Program onboarding (billing-org linkage) — see
+    # release/README.md and memory/project_aws_open_data_grant.md.
+  - Description: New-object notifications for the kietzmannlab-avs S3 bucket (from AWS's
+      public-dataset CloudFormation template's default SNS topic).
+    ARN: arn:aws:sns:us-west-2:406194432886:kietzmannlab-avs-object_created
+    Region: us-west-2
+    Type: SNS Topic
+
+DataAtWork:
+  Tutorials:
+    - Title: "Get To Know A Dataset: Active Visual Semantics (AVS)"
+      URL: https://github.com/KietzmannLab/pyavs/blob/main/examples/get-to-know-a-dataset.ipynb
+      AuthorName: Philip Sulewski
+      # Required first tutorial entry per the ODP handbook (Section 2.3). Runs end-to-end
+      # against the live public bucket, no credentials needed. Pending: this URL will 404
+      # until examples/get-to-know-a-dataset.ipynb is committed and pushed to pyavs main.
+    - Title: pyAVS Colab Quickstart
+      URL: https://colab.research.google.com/github/KietzmannLab/pyavs/blob/main/examples/pyavs_colab_quickstart.ipynb
+      NotebookURL: https://raw.githubusercontent.com/KietzmannLab/pyavs/main/examples/pyavs_colab_quickstart.ipynb
+      AuthorName: Philip Sulewski
+  Publications:
+    - Title: Fixation duration on natural scenes is explained by memory encoding not processing demand
+      URL: https://doi.org/10.1038/s41593-026-02285-1
+      AuthorName: Philip Sulewski et al.
+      # Interim citation: uses the AVS dataset but is not the dataset paper itself
+      # (Sulewski et al., "Active Visual Semantics..."), which is in preparation for submission. 

--- a/datasets/avs.yaml
+++ b/datasets/avs.yaml
@@ -27,9 +27,8 @@ Contact: Philip Sulewski (phsulewski@gmail.com)
 ManagedBy: "[Kietzmann Lab](https://kietzmannlab.uni-osnabrueck.de) at Universität Osnabrück"
 
 UpdateFrequency: >
-  Initial release as a single batch. Select additional derivative artifacts (e.g.
-  caption-to-object matching tables, scene-sampling metadata) are planned for future addition;
-  no fixed update schedule otherwise.
+  Initial release as a single batch, including caption-to-object matching tables and
+  scene-sampling metadata. No fixed update schedule.
 
 Tags:
   - aws-pds
@@ -51,10 +50,8 @@ Resources:
     ARN: arn:aws:s3:::kietzmannlab-avs
     Region: us-west-2
     Type: S3 Bucket
-    # Bucket currently holds only a partial demo subset (sub-01, 4/10 sessions, ~50 GiB) for
-    # ODP-review/tutorial purposes. The full ~712 GiB release upload is pending completion of
-    # AWS Open Data Sponsorship Program onboarding (billing-org linkage) — see
-    # release/README.md and memory/project_aws_open_data_grant.md.
+    # Full release uploaded 2026-08-25: 18,415 objects, ~663 GiB, verified against the
+    # release manifest.
   - Description: New-object notifications for the kietzmannlab-avs S3 bucket (from AWS's
       public-dataset CloudFormation template's default SNS topic).
     ARN: arn:aws:sns:us-west-2:406194432886:kietzmannlab-avs-object_created
@@ -67,8 +64,7 @@ DataAtWork:
       URL: https://github.com/KietzmannLab/pyavs/blob/main/examples/get-to-know-a-dataset.ipynb
       AuthorName: Philip Sulewski
       # Required first tutorial entry per the ODP handbook (Section 2.3). Runs end-to-end
-      # against the live public bucket, no credentials needed. Pending: this URL will 404
-      # until examples/get-to-know-a-dataset.ipynb is committed and pushed to pyavs main.
+      # against the live public bucket, no credentials needed.
     - Title: pyAVS Colab Quickstart
       URL: https://colab.research.google.com/github/KietzmannLab/pyavs/blob/main/examples/pyavs_colab_quickstart.ipynb
       NotebookURL: https://raw.githubusercontent.com/KietzmannLab/pyavs/main/examples/pyavs_colab_quickstart.ipynb

--- a/datasets/avs.yaml
+++ b/datasets/avs.yaml
@@ -1,5 +1,4 @@
 Name: Active Visual Semantics
-
 Description: >
   The Active Visual Semantics (AVS) Dataset is a multimodal neuroimaging dataset combining
   magnetoencephalography (MEG), eye-tracking, and structural MRI, recorded from 5 participants


### PR DESCRIPTION
## Dataset

**Active Visual Semantics (AVS)** — a multimodal neuroimaging dataset combining MEG,
eye-tracking, and structural MRI from 5 participants freely exploring 4,080 natural
scenes (subsampled from MS-COCO / NSD) across 10 sessions each, with a semantic
scene-captioning task on a subset of trials. Released under CC BY 4.0 by the
Kietzmann Lab, Universität Osnabrück.

- S3 bucket: `s3://kietzmannlab-avs` (us-west-2)
- Documentation: https://kietzmannlab.uni-osnabrueck.de/avs/
- Companion package: https://github.com/KietzmannLab/pyavs

## Status

Submitted as part of onboarding to the AWS Open Data Sponsorship Program (application
accepted). This PR is a **draft** while the remaining onboarding steps are completed:
Terms & Conditions signature, and linking the hosting AWS account to AWS's ODP billing
organization. The bucket currently holds a partial demo subset (~50 GiB, sub-01 only)
for review purposes; the full release (~712 GiB, all 5 subjects) will follow once
billing linkage is confirmed.

Included with this submission:
- Registry entry: `datasets/avs.yaml`
- Required "Get To Know A Dataset" tutorial notebook (Section 2.3 of the onboarding
  handbook), runnable end-to-end against the live public bucket with no credentials:
  https://github.com/KietzmannLab/pyavs/blob/main/examples/get-to-know-a-dataset.ipynb
- Dataset logo, sent separately to opendata@amazon.com per the handbook.

Validated locally against `schema.yaml` (aside from `RegistryEntryAdded` /
`RegistryEntryLastModified`, which per `_scripts/add_metadata.sh` are stamped from git
history and are absent from every currently-merged entry I checked, e.g. `nsd.yaml`).