### PR TITLE
Add ProofAML sanctions/PEP/watchlist datasets (5)

### DIFF
--- a/datasets/proofaml-global-export-control-denied-party.yaml
+++ b/datasets/proofaml-global-export-control-denied-party.yaml
@@ -1,0 +1,59 @@
+Name: ProofAML — Global Export Control & Denied-Party Lists Dataset
+
+Description: |
+  US BIS/DDTC/DHS and China MOFCOM export-control and denied-party lists, for trade-compliance screening.
+
+  A type-axis segment of the ProofAML corpus (global-export-control-denied-party) — 5,349 entity records across 8 sources, each traced to its original issuing authority.
+
+  A completely different buyer than the financial-sanctions segment: export-control/trade-compliance officers screening physical-goods shipments and counterparties, not financial transactions. The BIS Entity List, DDTC AECA Debarred List, DHS UFLPA list, and China's MOFCOM lists are the standard denied-party-screening stack for this persona and are conventionally bundled together in commercial trade-compliance tools — this segment mirrors that convention rather than inventing a new one. Zero overlap with the financial-sanctions segment's source IDs.
+
+  OVERLAP: This dataset overlaps with other ProofAML segment datasets and the master snapshot — entities are not unique to this file. See https://proofaml.com/sources/ for the full corpus and the other available segments.
+
+  Licensing: the selection, arrangement, and entity-resolution layer of this compilation is licensed CC BY 4.0. Every individual record additionally carries its own upstream publisher's license — see the bundle's own NOTICE file for the full per-source breakdown before redistributing any individual record in isolation.
+
+  Research snapshot — not current data; production sanctions screening requires a live, monitored feed.
+
+  Recommended citation: ProofAML — https://proofaml.com — "ProofAML Global Export Control & Denied-Party Lists Dataset Snapshot 2026-08-24"
+
+Documentation: https://proofaml.com/sources/
+
+Contact: "[ProofAML — open a GitHub issue](https://github.com/proofaml/sanctions-snapshot/issues)"
+
+ManagedBy: "[ProofAML](https://proofaml.com)"
+
+UpdateFrequency: Quarterly (to start; monthly at most)
+
+Tags:
+  - government records
+  - legal data
+  - regulatory
+
+License: >-
+  CC BY 4.0 (https://creativecommons.org/licenses/by/4.0/legalcode) — applies
+  ONLY to ProofAML's selection/arrangement/entity-resolution compilation
+  layer. Every individual record separately carries its own upstream
+  publisher's license; see the bundle's NOTICE file for the full per-source
+  breakdown.
+
+Resources:
+  - Description: >-
+      ProofAML — Global Export Control & Denied-Party Lists Dataset (version 2026-08-24) — object
+      prefix in the shared proofaml-open-data S3 bucket hosting this segment's
+      redistributable bundle (compressed archive, manifest.json with per-dataset
+      checksums, LICENSE, and the per-source NOTICE).
+    ARN: arn:aws:s3:::proofaml-open-data
+    Region: us-east-1
+    Type: S3 Bucket
+    Explore:
+      - '[Segment manifest (JSON)](https://proofaml-open-data.s3.us-east-1.amazonaws.com/segments/global-export-control-denied-party/2026-08-24/proofaml-global-export-control-denied-party-2026-08-24/manifest.json)'
+
+DataAtWork:
+  Tutorials: []
+  Tools & Applications: []
+  Publications:
+    - Title: "ProofAML — Global Export Control & Denied-Party Lists Dataset (archived, DOI-minted on Zenodo)"
+      URL: https://doi.org/10.5281/zenodo.22118978
+      AuthorName: ProofAML
+
+Citation: >-
+  ProofAML — https://proofaml.com — "ProofAML Global Export Control & Denied-Party Lists Dataset Snapshot 2026-08-24"

--- a/datasets/proofaml-global-pep-census.yaml
+++ b/datasets/proofaml-global-pep-census.yaml
@@ -1,0 +1,60 @@
+Name: ProofAML — Global PEP Census Dataset
+
+Description: |
+  51,751 politically exposed persons, all official government/IGO sources, zero Wikidata.
+
+  A type-axis segment of the ProofAML corpus (global-pep-census) — 51,751 entity records across 21 sources, each traced to its original issuing authority.
+
+  This is the deliverable that operationalizes the existing "Global PEP Census" flagship narrative page as an actual downloadable, separately-citable bundle. Reuses the existing brand name rather than inventing a second, competing "PEP dataset" concept. No sanctions/wanted/watchlist rows at all — pure PEP, which is the entire point (a PEP flag is a classification requiring enhanced due diligence, never a designation, per the product's own sanctions/PEP bifurcation). All sources are official government or intergovernmental publications; no crowdsourced (Wikidata) data.
+
+  OVERLAP: This dataset overlaps with other ProofAML segment datasets and the master snapshot — entities are not unique to this file. See https://proofaml.com/sources/ for the full corpus and the other available segments.
+
+  Licensing: the selection, arrangement, and entity-resolution layer of this compilation is licensed CC BY 4.0. Every individual record additionally carries its own upstream publisher's license — see the bundle's own NOTICE file for the full per-source breakdown before redistributing any individual record in isolation.
+
+  Research snapshot — not current data; production sanctions screening requires a live, monitored feed.
+
+  Recommended citation: ProofAML — https://proofaml.com — "ProofAML Global PEP Census Dataset Snapshot 2026-08-24"
+
+Documentation: https://proofaml.com/sources/
+
+Contact: "[ProofAML — open a GitHub issue](https://github.com/proofaml/sanctions-snapshot/issues)"
+
+ManagedBy: "[ProofAML](https://proofaml.com)"
+
+UpdateFrequency: Quarterly (to start; monthly at most)
+
+Tags:
+  - government records
+  - civic
+  - legal data
+  - regulatory
+
+License: >-
+  CC BY 4.0 (https://creativecommons.org/licenses/by/4.0/legalcode) — applies
+  ONLY to ProofAML's selection/arrangement/entity-resolution compilation
+  layer. Every individual record separately carries its own upstream
+  publisher's license; see the bundle's NOTICE file for the full per-source
+  breakdown.
+
+Resources:
+  - Description: >-
+      ProofAML — Global PEP Census Dataset (version 2026-08-24) — object
+      prefix in the shared proofaml-open-data S3 bucket hosting this segment's
+      redistributable bundle (compressed archive, manifest.json with per-dataset
+      checksums, LICENSE, and the per-source NOTICE).
+    ARN: arn:aws:s3:::proofaml-open-data
+    Region: us-east-1
+    Type: S3 Bucket
+    Explore:
+      - '[Segment manifest (JSON)](https://proofaml-open-data.s3.us-east-1.amazonaws.com/segments/global-pep-census/2026-08-24/proofaml-global-pep-census-2026-08-24/manifest.json)'
+
+DataAtWork:
+  Tutorials: []
+  Tools & Applications: []
+  Publications:
+    - Title: "ProofAML — Global PEP Census Dataset (archived, DOI-minted on Zenodo)"
+      URL: https://doi.org/10.5281/zenodo.22118981
+      AuthorName: ProofAML
+
+Citation: >-
+  ProofAML — https://proofaml.com — "ProofAML Global PEP Census Dataset Snapshot 2026-08-24"

--- a/datasets/proofaml-global-sanctions-regulatory-enforcement.yaml
+++ b/datasets/proofaml-global-sanctions-regulatory-enforcement.yaml
@@ -1,0 +1,60 @@
+Name: ProofAML — Global Sanctions & Regulatory Enforcement Dataset
+
+Description: |
+  The core OFAC/UN/EU/UK/Canada sanctions lists plus bank-regulator enforcement actions, in one file.
+
+  A type-axis segment of the ProofAML corpus (global-sanctions-regulatory-enforcement) — 46,015 entity records across 15 sources, each traced to its original issuing authority.
+
+  This is the file an AML/BSA sanctions-screening officer actually screens against day to day — every major Western financial-sanctions regime (US, UN, EU, UK, Canada) plus the regulator enforcement actions (MAS, FINTRAC, DNB) a compliance team monitors alongside them. It excludes export-control/trade-compliance data (see the Global Export Control & Denied-Party segment) and PEP data (see the Global PEP Census segment) on purpose: a buyer who wants "just the sanctions lists" doesn't want to wade through 51,751 PEP records or 5,349 denied-party records to get there. Distinct from the master (120,886 entities, 69 sources spanning four unrelated data types) by being exactly the subset one specific job function needs.
+
+  OVERLAP: This dataset overlaps with other ProofAML segment datasets and the master snapshot — entities are not unique to this file. See https://proofaml.com/sources/ for the full corpus and the other available segments.
+
+  Licensing: the selection, arrangement, and entity-resolution layer of this compilation is licensed CC BY 4.0. Every individual record additionally carries its own upstream publisher's license — see the bundle's own NOTICE file for the full per-source breakdown before redistributing any individual record in isolation.
+
+  Research snapshot — not current data; production sanctions screening requires a live, monitored feed.
+
+  Recommended citation: ProofAML — https://proofaml.com — "ProofAML Global Sanctions & Regulatory Enforcement Dataset Snapshot 2026-08-24"
+
+Documentation: https://proofaml.com/sources/
+
+Contact: "[ProofAML — open a GitHub issue](https://github.com/proofaml/sanctions-snapshot/issues)"
+
+ManagedBy: "[ProofAML](https://proofaml.com)"
+
+UpdateFrequency: Quarterly (to start; monthly at most)
+
+Tags:
+  - financial markets
+  - government records
+  - legal data
+  - regulatory
+
+License: >-
+  CC BY 4.0 (https://creativecommons.org/licenses/by/4.0/legalcode) — applies
+  ONLY to ProofAML's selection/arrangement/entity-resolution compilation
+  layer. Every individual record separately carries its own upstream
+  publisher's license; see the bundle's NOTICE file for the full per-source
+  breakdown.
+
+Resources:
+  - Description: >-
+      ProofAML — Global Sanctions & Regulatory Enforcement Dataset (version 2026-08-24) — object
+      prefix in the shared proofaml-open-data S3 bucket hosting this segment's
+      redistributable bundle (compressed archive, manifest.json with per-dataset
+      checksums, LICENSE, and the per-source NOTICE).
+    ARN: arn:aws:s3:::proofaml-open-data
+    Region: us-east-1
+    Type: S3 Bucket
+    Explore:
+      - '[Segment manifest (JSON)](https://proofaml-open-data.s3.us-east-1.amazonaws.com/segments/global-sanctions-regulatory-enforcement/2026-08-24/proofaml-global-sanctions-regulatory-enforcement-2026-08-24/manifest.json)'
+
+DataAtWork:
+  Tutorials: []
+  Tools & Applications: []
+  Publications:
+    - Title: "ProofAML — Global Sanctions & Regulatory Enforcement Dataset (archived, DOI-minted on Zenodo)"
+      URL: https://doi.org/10.5281/zenodo.22118976
+      AuthorName: ProofAML
+
+Citation: >-
+  ProofAML — https://proofaml.com — "ProofAML Global Sanctions & Regulatory Enforcement Dataset Snapshot 2026-08-24"

--- a/datasets/proofaml-global-wanted-persons-doj-enforcement.yaml
+++ b/datasets/proofaml-global-wanted-persons-doj-enforcement.yaml
@@ -1,0 +1,59 @@
+Name: ProofAML — Global Wanted Persons & Law-Enforcement Enforcement Actions Dataset
+
+Description: |
+  FBI/ICE/Secret Service/ATF/USPIS most-wanted lists, DOJ enforcement defendants, plus UK/NL/PL wanted.
+
+  A type-axis segment of the ProofAML corpus (global-wanted-persons-doj-enforcement) — 17,661 entity records across 10 sources, each traced to its original issuing authority.
+
+  An entirely different audience from the AML/compliance buyer the rest of this corpus targets: investigators, background-check vendors, and OSINT/investigative-journalism users who want active-fugitive and federal-enforcement-defendant data specifically, not sanctions or PEP records. No overlap with the sanctions, export-control, or PEP segments' source IDs.
+
+  OVERLAP: This dataset overlaps with other ProofAML segment datasets and the master snapshot — entities are not unique to this file. See https://proofaml.com/sources/ for the full corpus and the other available segments.
+
+  Licensing: the selection, arrangement, and entity-resolution layer of this compilation is licensed CC BY 4.0. Every individual record additionally carries its own upstream publisher's license — see the bundle's own NOTICE file for the full per-source breakdown before redistributing any individual record in isolation.
+
+  Research snapshot — not current data; production sanctions screening requires a live, monitored feed.
+
+  Recommended citation: ProofAML — https://proofaml.com — "ProofAML Global Wanted Persons & Law-Enforcement Enforcement Actions Dataset Snapshot 2026-08-24"
+
+Documentation: https://proofaml.com/sources/
+
+Contact: "[ProofAML — open a GitHub issue](https://github.com/proofaml/sanctions-snapshot/issues)"
+
+ManagedBy: "[ProofAML](https://proofaml.com)"
+
+UpdateFrequency: Quarterly (to start; monthly at most)
+
+Tags:
+  - government records
+  - legal data
+  - civic
+
+License: >-
+  CC BY 4.0 (https://creativecommons.org/licenses/by/4.0/legalcode) — applies
+  ONLY to ProofAML's selection/arrangement/entity-resolution compilation
+  layer. Every individual record separately carries its own upstream
+  publisher's license; see the bundle's NOTICE file for the full per-source
+  breakdown.
+
+Resources:
+  - Description: >-
+      ProofAML — Global Wanted Persons & Law-Enforcement Enforcement Actions Dataset (version 2026-08-24) — object
+      prefix in the shared proofaml-open-data S3 bucket hosting this segment's
+      redistributable bundle (compressed archive, manifest.json with per-dataset
+      checksums, LICENSE, and the per-source NOTICE).
+    ARN: arn:aws:s3:::proofaml-open-data
+    Region: us-east-1
+    Type: S3 Bucket
+    Explore:
+      - '[Segment manifest (JSON)](https://proofaml-open-data.s3.us-east-1.amazonaws.com/segments/global-wanted-persons-doj-enforcement/2026-08-24/proofaml-global-wanted-persons-doj-enforcement-2026-08-24/manifest.json)'
+
+DataAtWork:
+  Tutorials: []
+  Tools & Applications: []
+  Publications:
+    - Title: "ProofAML — Global Wanted Persons & Law-Enforcement Enforcement Actions Dataset (archived, DOI-minted on Zenodo)"
+      URL: https://doi.org/10.5281/zenodo.22118983
+      AuthorName: ProofAML
+
+Citation: >-
+  ProofAML — https://proofaml.com — "ProofAML Global Wanted Persons & Law-Enforcement Enforcement Actions Dataset Snapshot 2026-08-24"

--- a/datasets/proofaml-sanctions-snapshot.yaml
+++ b/datasets/proofaml-sanctions-snapshot.yaml
@@ -1,0 +1,76 @@
+Name: ProofAML Sanctions & PEP Watchlist Snapshot
+
+Description: |
+  A versioned, redistributable snapshot of ProofAML's resolved global
+  sanctions, watchlist, and politically-exposed-person (PEP) corpus —
+  120,886 entity records across 69 datasets, each traced to its original
+  issuing authority (OFAC, the UN Security Council, the EU, UK OFSI,
+  national parliaments, the CIA World Leaders directory, and more). The
+  PEP subset is sourced entirely from official government and
+  international-organization publications, not crowdsourced data.
+
+  Licensing: the selection, arrangement, and entity-resolution layer of
+  this compilation is licensed CC BY 4.0. Every individual record
+  additionally carries its own upstream publisher's license (US public
+  domain, UK Open Government Licence v3, EU Commission Decision
+  2011/833/EU, UN CC BY 3.0 IGO, France Licence Ouverte/Etalab, CC0,
+  Nordic NLOD, and others) — see the bundle's own NOTICE file for the
+  full per-source breakdown before redistributing any individual record
+  in isolation. Sources evaluated but excluded (share-alike terms, no
+  snapshot artifact yet) are listed transparently in manifest.json's
+  "excluded" array.
+
+  Research snapshot — not current data; production sanctions screening
+  requires a live, monitored feed.
+
+  Recommended citation: ProofAML — https://proofaml.com —
+  "ProofAML Sanctions Snapshot 2026-08-24"
+
+Documentation: https://proofaml.com/sources/
+
+Contact: "[ProofAML — open a GitHub issue](https://github.com/proofaml/sanctions-snapshot/issues)"
+
+ManagedBy: "[ProofAML](https://proofaml.com)"
+
+UpdateFrequency: Quarterly (to start; monthly at most)
+
+Tags:
+  - financial markets
+  - government records
+  - legal data
+  - regulatory
+  - civic
+
+License: >-
+  CC BY 4.0 (https://creativecommons.org/licenses/by/4.0/legalcode) —
+  applies ONLY to ProofAML's selection/arrangement/entity-resolution
+  compilation layer. Every individual record separately carries its own
+  upstream publisher's license (US public domain, UK OGL v3, EU
+  2011/833/EU, UN CC BY 3.0 IGO, and others); see the bundle's NOTICE file
+  for the full per-source breakdown.
+
+Resources:
+  - Description: >-
+      ProofAML Sanctions & PEP Watchlist Snapshot (version 2026-08-24) —
+      S3 bucket hosting the versioned, redistributable dataset bundle
+      (compressed archive, manifest.json with per-dataset checksums,
+      LICENSE, and the per-source NOTICE). Bucket is public — anonymous
+      s3:GetObject, us-east-1, no-cost download.
+    ARN: arn:aws:s3:::proofaml-open-data
+    Region: us-east-1
+    Type: S3 Bucket
+    Explore:
+      - '[Dataset manifest (JSON)](https://proofaml-open-data.s3.us-east-1.amazonaws.com/snapshot/2026-08-24/proofaml-sanctions-snapshot-2026-08-24/manifest.json)'
+
+DataAtWork:
+  Tutorials: []
+  Tools & Applications: []
+  Publications:
+    - Title: "ProofAML Sanctions & PEP Watchlist Snapshot (archived, DOI-minted on Zenodo)"
+      URL: https://doi.org/10.5281/zenodo.22115768
+      AuthorName: ProofAML
+
+Citation: >-
+  ProofAML. (2026). ProofAML Sanctions & PEP Watchlist Snapshot
+  (Version 2026-08-24) [Data set]. Zenodo.
+  https://doi.org/10.5281/zenodo.22115768


### PR DESCRIPTION
## Summary

Adds 5 dataset entries for [ProofAML](https://proofaml.com), a resolved, cross-source global sanctions / PEP / watchlist corpus. All bundles are hosted publicly (anonymous `s3:GetObject`, no cost) in the `proofaml-open-data` S3 bucket (`us-east-1`), each traced to its original issuing authority (OFAC, UN Security Council, EU, UK OFSI, national parliaments, the CIA World Leaders directory, and more). Every record's individual upstream license is documented in the bundle's NOTICE file; ProofAML's own selection/arrangement/entity-resolution layer is CC BY 4.0.

- **`datasets/proofaml-sanctions-snapshot.yaml`** — the master snapshot: 120,886 entity records across 69 sources spanning sanctions, export-control, PEP, and wanted-persons data.
- **`datasets/proofaml-global-sanctions-regulatory-enforcement.yaml`** — core OFAC/UN/EU/UK/Canada sanctions lists plus bank-regulator enforcement actions (46,015 records, 15 sources).
- **`datasets/proofaml-global-export-control-denied-party.yaml`** — US BIS/DDTC/DHS and China MOFCOM export-control and denied-party lists (5,349 records, 8 sources).
- **`datasets/proofaml-global-pep-census.yaml`** — politically-exposed-persons census sourced entirely from official government/IGO publications, no crowdsourced data (51,751 records, 21 sources).
- **`datasets/proofaml-global-wanted-persons-doj-enforcement.yaml`** — FBI/ICE/Secret Service/ATF/USPIS most-wanted lists plus DOJ enforcement defendants and UK/NL/PL wanted persons (17,661 records, 10 sources).

The four segment datasets are type-axis subsets of the master snapshot, published separately for buyers who only need one data type. Each dataset is also archived with its own DOI on Zenodo (linked under `DataAtWork.Publications`).

## Test plan

- [x] Verified all 5 `Explore` manifest URLs return HTTP 200 (publicly reachable, no credentials).
- [x] Verified all `Tags` values exist in the current `tags.yaml` enum.
- [x] Verified the `Resources[].Type` value (`S3 Bucket`) exists in `resources.yaml` and the ARN matches `ext_resources_arn`'s pattern.
- [x] Installed `requirements.txt` and ran `pykwalify -d datasets/<file>.yaml -s schema.yaml` for each of the 5 files. All 5 pass with only the `RegistryEntryAdded`/`RegistryEntryLastModified` keys missing — confirmed (by running the same check against already-merged files such as `aws-public-blockchain.yaml`) that these two fields are stamped by this repo's own CI (`_scripts/add_metadata.sh`, from git history) rather than supplied by contributors, matching the convention of every other file in `datasets/`.