### PR TITLE
add geonadir-fair-data.yaml for aws open data registry

### DIFF
--- a/datasets/geonadir-fair-data.yaml
+++ b/datasets/geonadir-fair-data.yaml
@@ -1,0 +1,108 @@
+Name: GeoNadir FAIR Data
+Description: |
+  <br/>
+  <br/>
+  GeoNadir FAIR Data is an open collection of uncrewed aerial vehicle (UAV or drone) mapping datasets
+  contributed through the GeoNadir platform and published as cloud-native
+  geospatial files on Amazon S3.
+  <br/>
+  <br/>
+  Each dataset represents one drone survey. Every dataset provides a normalized
+  metadata file and a ZIP package of the original raw images. Where available,
+  a dataset may also include an RGB orthomosaic, a multispectral orthomosaic,
+  a Digital Surface Model (DSM), and a Digital Terrain Model (DTM), each stored
+  as a Cloud Optimized GeoTIFF (COG) that can be read directly by GDAL,
+  Rasterio, QGIS, and other cloud-native geospatial tools without downloading
+  the full file.
+  <br/>
+  <br/>
+  The files are addressable directly on Amazon S3 by a stable key convention, so
+  the collection is fully usable today with standard tools such as boto3,
+  Rasterio, GDAL, and QGIS: list the datasets prefix, read each survey's
+  metadata file, and open its COGs by their known keys.
+  <br/>
+  <br/>
+  A STAC-compatible catalog for richer discovery — search by capture date,
+  upload date, spatial area of interest, and metadata fields such as IUCN
+  habitat classification — is planned and will be added after the initial
+  launch. 
+  <br/>
+  <br/>
+  The collection includes only datasets that GeoNadir is able to publish
+  publicly under the Creative Commons Attribution 4.0
+  International license (CC-BY-4.0) license. Private workspace data and unpublished
+  datasets are out of scope for this collection.
+Documentation: https://github.com/Geonadir/open-data-examples/blob/main/OPEN_DATA_STRUCTURE.md
+Contact: opendata@geonadir.com
+ManagedBy: "[GeoNadir](https://geonadir.com/)"
+UpdateFrequency: New drone mapping datasets are added as they are contributed and cleared for open publication.
+Tags:
+  - aerial imagery
+  - geospatial
+  - earth observation
+  - cog
+  - stac
+  - dem
+  - elevation
+  - mapping
+  - land cover
+  - land use
+  - biodiversity
+  - conservation
+  - environmental
+  - agriculture
+  - coastal
+  - sustainability
+  - drone
+  - UAV
+License: |
+  This dataset is licensed under the Creative Commons Attribution 4.0
+  International license (CC-BY-4.0). You are free to share and adapt the
+  material for any purpose, provided you give appropriate credit to GeoNadir
+  and the contributing data provider. Full license text is available at
+  https://creativecommons.org/licenses/by/4.0/
+Citation: 'GeoNadir FAIR Data was accessed on DATE from https://registry.opendata.aws/geonadir-fair-data. GeoNadir. 2026. GeoNadir FAIR Data: open drone mapping datasets.'
+RegistryEntryAdded: '2026-08-24'
+RegistryEntryLastModified: '2026-08-31'
+Resources:
+  - Description: GeoNadir FAIR Data drone mapping datasets (Cloud Optimized GeoTIFFs, raw image ZIPs, and per-dataset JSON metadata)
+    ARN: arn:aws:s3:::geonadir-fair-data
+    Region: ap-southeast-2
+    Type: S3 Bucket
+    Explore:
+      - '[Browse GeoNadir FAIR Data](https://data.geonadir.com/fairgeo)'
+      # STAC is not live yet. Re-add this Explore link only once
+      # https://data.geonadir.com/stac/collections/geonadir-fair-data returns a
+      # valid STAC collection (a dead link here would 404 on the registry page):
+      #   - '[STAC catalog](https://data.geonadir.com/stac/collections/geonadir-fair-data)'
+# DRAFT NOTE (remove before taking PR out of draft):
+#   1. Confirm the final bucket name once the AWS Open Data CloudFormation stack
+#      has been created in the dedicated open-data account. If the name differs
+#      from "geonadir-fair-data", update the ARN above and every s3:// reference
+#      in OPEN_DATA_STRUCTURE.md and the tutorial notebook.
+#   2. The CloudFormation template also provisions an SNS topic for S3
+#      object-creation notifications. After the stack exists, add a second
+#      Resources entry for it, e.g.:
+#        - Description: New object notifications for GeoNadir FAIR Data (Lambda and SQS protocols only)
+#          ARN: arn:aws:sns:ap-southeast-2:209003640346:<topic-name>
+#          Region: ap-southeast-2
+#          Type: SNS Topic
+#   3. STAC is NOT live at launch. The STAC catalog Explore link is commented out
+#      above, and the STAC tutorial will not run until the endpoint exists.
+#      Re-enable both once https://data.geonadir.com/stac/ serves the collection.
+DataAtWork:
+  Tutorials:
+    - Title: 'Get To Know A Dataset: GeoNadir FAIR Data'
+      URL: https://github.com/Geonadir/open-data-examples/blob/main/datasets/geonadir-fair-data/get-to-know-a-dataset.ipynb
+      NotebookURL: https://raw.githubusercontent.com/Geonadir/open-data-examples/main/datasets/geonadir-fair-data/get-to-know-a-dataset.ipynb
+      AuthorName: GeoNadir
+      AuthorURL: https://geonadir.com/
+      Services:
+        - Amazon S3
+    - Title: 'Get To Know A Dataset: GeoNadir FAIR Data (STAC catalog — runs once the STAC endpoint is live)'
+      URL: https://github.com/Geonadir/open-data-examples/blob/main/datasets/geonadir-fair-data/get-to-know-a-dataset-stac.ipynb
+      NotebookURL: https://raw.githubusercontent.com/Geonadir/open-data-examples/main/datasets/geonadir-fair-data/get-to-know-a-dataset-stac.ipynb
+      AuthorName: GeoNadir
+      AuthorURL: https://geonadir.com/
+      Services:
+        - Amazon S3

--- a/datasets/geonadir-fair-data.yaml
+++ b/datasets/geonadir-fair-data.yaml
@@ -94,14 +94,12 @@ DataAtWork:
   Tutorials:
     - Title: 'Get To Know A Dataset: GeoNadir FAIR Data'
       URL: https://github.com/Geonadir/open-data-examples/blob/main/datasets/geonadir-fair-data/get-to-know-a-dataset.ipynb
-      NotebookURL: https://raw.githubusercontent.com/Geonadir/open-data-examples/main/datasets/geonadir-fair-data/get-to-know-a-dataset.ipynb
       AuthorName: GeoNadir
       AuthorURL: https://geonadir.com/
       Services:
         - Amazon S3
     - Title: 'Get To Know A Dataset: GeoNadir FAIR Data (STAC catalog — runs once the STAC endpoint is live)'
       URL: https://github.com/Geonadir/open-data-examples/blob/main/datasets/geonadir-fair-data/get-to-know-a-dataset-stac.ipynb
-      NotebookURL: https://raw.githubusercontent.com/Geonadir/open-data-examples/main/datasets/geonadir-fair-data/get-to-know-a-dataset-stac.ipynb
       AuthorName: GeoNadir
       AuthorURL: https://geonadir.com/
       Services:


### PR DESCRIPTION
Adds the **GeoNadir FAIR Data** collection — open, CC-BY-4.0 UAV (drone) mapping
datasets contributed through GeoNadir, published as cloud-native files (COGs,
raw-image ZIPs, per-dataset JSON metadata) in `ap-southeast-2`.

Opening as a **draft**: we're mid-onboarding in the AWS Open Data Sponsorship
Program (dedicated account created, account-linking in progress). The bucket is
provisioned via the program's CloudFormation template shortly, so the S3
resource is provisional until then. Descriptive docs and a tutorial notebook are
already linked in the entry.

- License: CC-BY-4.0
- Region: ap-southeast-2
- Docs: https://github.com/Geonadir/open-data-examples/blob/main/OPEN_DATA_STRUCTURE.md
- Contact: opendata@geonadir.com

Happy to adjust anything for the linter or registry conventions.