### PR TITLE
Overture: add Turkey business digital presence report to DataAtWork

### DIFF
--- a/datasets/overture.yaml
+++ b/datasets/overture.yaml
@@ -37,6 +37,10 @@ DataAtWork:
       AuthorName: Overture Maps Foundation
   Tools & Applications:
   Publications:
+    - Title: "Turkey Business Digital Presence 2026: 1.79M Overture places, with every listed website crawled"
+      URL: https://crmsolid.com/research/turkey-business-digital-report
+      AuthorName: CRM Solid
+      AuthorURL: https://crmsolid.com
     - Title: "Building Heights: From open USGS lidar to open Overture maps"
       URL: https://project.linuxfoundation.org/hubfs/Overture%20Maps/Building%20Heights%20Whitepaper_041423.pdf
       AuthorName: Overture Maps Foundation


### PR DESCRIPTION
Adds one entry to the Overture Maps dataset's `DataAtWork > Publications`.

**What it is:** an analysis of the full Turkish extract of Overture places (1,786,700 records), published as open data under CC BY 4.0 with province and sector breakdowns, CSV/JSON downloads, and a documented method. It is also archived on Zenodo with a DOI (10.5281/zenodo.22217770).

**Why it may be useful to other Overture users:**

- It documents two data characteristics that anyone working with the Turkish extract will hit: the address `region` field is null on roughly 92% of Turkish records (so province has to be assigned by point-in-polygon), and the `socials` array for Turkey is ~98% Facebook with only ~14k Instagram.
- It reports what fraction of the `websites` field is actually live: of 684,496 records with a website, 413,777 respond. That gap is worth knowing before treating the field as a presence signal.

The work was done with DuckDB reading the GeoParquet release directly from the S3 bucket listed in this registry entry.
