### PR TITLE
Update dynamical.org noaa-hrrr

### DIFF
--- a/datasets/dynamical-noaa-hrrr.yaml
+++ b/datasets/dynamical-noaa-hrrr.yaml
@@ -8,10 +8,11 @@ Description: |
     - [NOAA HRRR forecast, 48 hour](https://dynamical.org/catalog/noaa-hrrr-forecast-48-hour/) - Weather forecasts from the High-Resolution Rapid Refresh (HRRR) model operated by NOAA NWS NCEP.
     - [NOAA HRRR forecast, 48 hour, virtual](https://dynamical.org/catalog/noaa-hrrr-forecast-48-hour-virtual/) - Weather forecasts from the High-Resolution Rapid Refresh (HRRR) model operated by NOAA NWS NCEP.
     - [NOAA HRRR analysis](https://dynamical.org/catalog/noaa-hrrr-analysis/) - Analysis data from the High-Resolution Rapid Refresh (HRRR) model operated by NOAA NWS NCEP.
+    - [NOAA HRRR analysis, virtual](https://dynamical.org/catalog/noaa-hrrr-analysis-virtual/) - Analysis data from the High-Resolution Rapid Refresh (HRRR) model operated by NOAA NWS NCEP.
 Documentation: https://dynamical.org/catalog/
 Contact: feedback@dynamical.org
 ManagedBy: "[dynamical.org](https://dynamical.org)"
-UpdateFrequency: "NOAA HRRR forecast, 18 hour, virtual: Forecasts initialized every hour; NOAA HRRR forecast, 48 hour: Forecasts initialized every 6 hours; NOAA HRRR forecast, 48 hour, virtual: Forecasts initialized every 6 hours; NOAA HRRR analysis: 1 hour"
+UpdateFrequency: "NOAA HRRR forecast, 18 hour, virtual: Forecasts initialized every hour; NOAA HRRR forecast, 48 hour: Forecasts initialized every 6 hours; NOAA HRRR forecast, 48 hour, virtual: Forecasts initialized every 6 hours; NOAA HRRR analysis: 1 hour; NOAA HRRR analysis, virtual: 1 hour"
 Tags:
   - aws-pds
   - weather
@@ -52,6 +53,11 @@ DataAtWork:
     - Title: "NOAA HRRR analysis — Quickstart"
       URL: https://github.com/dynamical-org/notebooks/blob/main/noaa-hrrr-analysis.ipynb
       NotebookURL: https://github.com/dynamical-org/notebooks/blob/main/noaa-hrrr-analysis.ipynb
+      AuthorName: dynamical.org
+      AuthorURL: https://dynamical.org
+    - Title: "NOAA HRRR analysis, virtual — Quickstart"
+      URL: https://github.com/dynamical-org/notebooks/blob/main/noaa-hrrr-analysis-virtual.ipynb
+      NotebookURL: https://github.com/dynamical-org/notebooks/blob/main/noaa-hrrr-analysis-virtual.ipynb
       AuthorName: dynamical.org
       AuthorURL: https://dynamical.org
 ADXCategories:


### PR DESCRIPTION
Update the dynamical.org noaa-hrrr dataset entry. Cloud-optimized Icechunk Zarr hosted by dynamical.org.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.