### PR TITLE
Add NDMDR registry draft

### DIFF
--- a/datasets/ndmdr.yaml
+++ b/datasets/ndmdr.yaml
@@ -30,3 +30,10 @@ RegistryEntryAdded: 2026-09-04
 
 RegistryEntryLastModified: 2026-09-04
 
+DataAtWork:
+  Tutorials:
+    - Title: "Get To Know A Dataset: Neurological Disease Multimodal Data Registry (NDMDR)"
+      URL: "https://github.com/Tahereh-K/open-data-examples/blob/main/ndmdr/get-to-know-a-dataset.ipynb"
+      AuthorName: "Tahereh Kamali"
+      Services:
+        - S3

--- a/datasets/ndmdr.yaml
+++ b/datasets/ndmdr.yaml
@@ -1,0 +1,32 @@
+Name: Neurological Disease Multimodal Data Registry (NDMDR)
+
+Description: >
+  The Neurological Disease Multimodal Data Registry (NDMDR) is a Stanford
+  University initiative providing access to de-identified multimodal datasets
+  for neurological and neuromuscular research. NDMDR is designed to support reproducible research,
+  biomarker development, and artificial intelligence and machine learning
+  applications in neurological and neuromuscular disorders.
+
+Documentation: https://ndmdr.stanford.edu/documentation.html
+
+Contact: https://ndmdr.stanford.edu/contact.html
+
+ManagedBy: Stanford University
+
+UpdateFrequency: As new datasets become available
+
+Tags:
+  - health
+  - life sciences
+  - medicine
+  - electrophysiology
+  - magnetic resonance imaging
+  - medical imaging
+  - machine learning
+
+License: See dataset-specific data use and licensing information at https://ndmdr.stanford.edu/documentation.html
+
+RegistryEntryAdded: 2026-09-04
+
+RegistryEntryLastModified: 2026-09-04
+


### PR DESCRIPTION
Issue #, if available: N/A

Description of changes:

Adds a draft Registry of Open Data on AWS entry for the Neurological Disease Multimodal Data Registry (NDMDR), a Stanford University initiative providing de-identified multimodal neurological and neuromuscular research datasets.

This is being submitted as a draft during onboarding to the AWS Open Data Sponsorship Program. AWS resource information will be added once the sponsored S3 bucket is provisioned.