### PR TITLE
Update implementation date for RRFS and REFS

### DIFF
--- a/datasets/noaa-rrfs-ops.yaml
+++ b/datasets/noaa-rrfs-ops.yaml
@@ -2,7 +2,7 @@ Name: "NOAA Rapid Refresh Forecast System (RRFS) and RRFS Ensemble Forecast Syst
 Description: |
   #### Update
 
-  Version 1 of the RRFS and REFS are scheduled to be implemented on October 6th, 2026 per the following [Service Change Notice](https://www.weather.gov/media/notification/pdf_2026/scn26-048_RRFS_and_REFS_Implementation.aab.pdf). Please note that upon the start of the pre-implementation parallel phase, August 12th, 2026, the RRFS/REFS [prototype data feed](https://noaa-rrfs-pds.s3.amazonaws.com/index.html) will no longer be updated.
+  Version 1 of the RRFS and REFS are scheduled to be implemented on October 14th, 2026 per the following [Service Change Notice](https://www.weather.gov/media/notification/pdf_2026/scn26-048_Updated_RRFS_and_REFS_Implementation_aad.pdf). Please note that upon the start of the pre-implementation parallel phase, August 12th, 2026, the RRFS/REFS [prototype data feed](https://noaa-rrfs-pds.s3.amazonaws.com/index.html) will no longer be updated.
   <br/><br/>
   Users will be able to access the operational data through this bucket or through the feeds noted in the Service Change Notice to receive the RRFS and REFS outputs. Note that the files, filenames, and directory structures in this bucket will align with those described in the Service Change Notice.
   <br/><br/>


### PR DESCRIPTION
Updated the implementation date for the RRFS and REFS from October 6th to October 14th, 2026, and modified the link in the Service Change Notice.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
