### PR TITLE
Update ERA5 dataset S3 location and remove Explore link

### DIFF
--- a/datasets/planette_era5_reanalysis.yaml
+++ b/datasets/planette_era5_reanalysis.yaml
@@ -36,11 +36,9 @@ Citation: |
 
 Resources:
   - Description: ERA5 Reanalysis Data with Multiple Temporal Aggregations (Zarr format)
-    ARN: arn:aws:s3:::planette-era5/era5/
+    ARN: arn:aws:s3:::planette-era5/ERA5_ic/
     Region: us-east-2
     Type: S3 Bucket
-    Explore:
-    - '[Browse Dataset](https://planette-era5.s3.amazonaws.com/index.html#era5/)'
 DataAtWork:
   Tutorials:
     - Title: Accessing ERA5 Data with Python


### PR DESCRIPTION
Changes:
* Updated the ERA5 dataset S3 URI from planette-era5/era5/ to planette-era5/ERA5_ic/
* Removed the Explore tab/link since the new dataset does not require or include an index.html file.

This updates the dataset configuration to point to the newly published ERA5 dataset and removes the now-unnecessary dataset browser link.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
