### PR TITLE
Update SEAS5 dataset S3 location and remove Explore link

### DIFF
--- a/datasets/planette_c3s_seasonal_forecast_data.yaml
+++ b/datasets/planette_c3s_seasonal_forecast_data.yaml
@@ -33,11 +33,9 @@ Citation: |
   https://cds.climate.copernicus.eu/cdsapp#!/dataset/seasonal-original-single-levels
 Resources:
   - Description: C3S Seasonal Forecast Hindcasts and Forecasts (Zarr format)
-    ARN: arn:aws:s3:::planette-c3s-seasonal-forecasts/seas5/
+    ARN: arn:aws:s3:::planette-c3s-seasonal-forecasts/seas5_ic/
     Region: us-east-2
     Type: S3 Bucket
-    Explore:
-    - '[Browse Dataset](https://planette-c3s-seasonal-forecasts.s3.amazonaws.com/index.html#seas5)'
 DataAtWork:
   Tutorials:
     - Title: Accessing C3S Seasonal Forecast Data with Python


### PR DESCRIPTION
Changes:
* Updated the SEAS5 dataset S3 URI from planette-c3s-seasonal-forecasts/seas5 to planette-c3s-seasonal-forecasts/seas5_ic.
* Removed the Explore tab/link since the new dataset does not require or include an index.html file.

This updates the dataset configuration to point to the newly published SEAS5 dataset and removes the now-unnecessary dataset browser link.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
